### PR TITLE
Bump arbitrary-int dependency

### DIFF
--- a/cortex-ar/CHANGELOG.md
+++ b/cortex-ar/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - MMU code: Use more `arbitrary-int` types for MMU configuration bits.
 - Renamed `L1Section::new` to `L1Section::new_with_addr_and_attrs`.
 - Bumped `defmt` to v1
+- Bumped `arbitrary-int` to v2
 
 ## [v0.2.0]
 

--- a/cortex-ar/Cargo.toml
+++ b/cortex-ar/Cargo.toml
@@ -25,7 +25,7 @@ rust-version = "1.83"
 version = "0.2.0"
 
 [dependencies]
-arbitrary-int = "1.3.0"
+arbitrary-int = "2"
 bitbybit = "1.3.3"
 num_enum = { version = "0.7", default-features = false }
 critical-section = {version = "1.2.0", features = ["restore-state-u8"], optional = true}

--- a/cortex-ar/src/register/dfsr.rs
+++ b/cortex-ar/src/register/dfsr.rs
@@ -1,6 +1,6 @@
 //! Code for managing DFSR (*Data Fault Status Register*)
 
-use arbitrary_int::{u4, u5, Number};
+use arbitrary_int::{prelude::*, u4, u5};
 
 use crate::register::{SysReg, SysRegRead, SysRegWrite};
 

--- a/cortex-ar/src/register/drsr.rs
+++ b/cortex-ar/src/register/drsr.rs
@@ -1,6 +1,6 @@
 //! Code for managing DRSR (*Data Region Size and Enable Register*)
 
-use arbitrary_int::Number;
+use arbitrary_int::prelude::*;
 
 use crate::register::{SysReg, SysRegRead, SysRegWrite};
 

--- a/cortex-ar/src/register/ifsr.rs
+++ b/cortex-ar/src/register/ifsr.rs
@@ -1,6 +1,6 @@
 //! Code for managing IFSR (*Instruction Fault Status Register*)
 
-use arbitrary_int::{u4, u5, Number};
+use arbitrary_int::{prelude::*, u4, u5};
 
 use crate::register::{SysReg, SysRegRead, SysRegWrite};
 


### PR DESCRIPTION
There is a new major release for `arbitrary-int` . While no explicit features are used yet, bumping the version allows moving to a higher `bitbybit` version in the future. 

We could probably support `arbitrary-int` v1 but is that worth the trouble?