### PR TITLE
Mark `asm::irq_enable` as unsafe

### DIFF
--- a/aarch32-cpu/CHANGELOG.md
+++ b/aarch32-cpu/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Mark `asm::irq_enable()` as unsafe to match `interrupt::enable()`
+
 ## [aarch32-cpu v0.1.0]
 
 ### Added

--- a/aarch32-cpu/src/asmv4.rs
+++ b/aarch32-cpu/src/asmv4.rs
@@ -30,7 +30,7 @@ pub fn irq_disable() {
 /// Unmask IRQ
 #[cfg_attr(not(feature = "check-asm"), inline)]
 #[cfg_attr(target_arch = "arm", instruction_set(arm::a32))]
-pub fn irq_enable() {
+pub unsafe fn irq_enable() {
     #[cfg(target_arch = "arm")]
     unsafe {
         core::arch::asm!(r#"

--- a/aarch32-cpu/src/asmv7.rs
+++ b/aarch32-cpu/src/asmv7.rs
@@ -82,7 +82,7 @@ pub fn irq_disable() {
 
 /// Unmask IRQ
 #[cfg_attr(not(feature = "check-asm"), inline)]
-pub fn irq_enable() {
+pub unsafe fn irq_enable() {
     unsafe {
         core::arch::asm!("cpsie i");
     }

--- a/aarch32-cpu/src/interrupt.rs
+++ b/aarch32-cpu/src/interrupt.rs
@@ -14,7 +14,10 @@ use core::sync::atomic::{compiler_fence, Ordering};
 pub unsafe fn enable() {
     // Ensure no preceeding memory accesses are reordered to after interrupts are enabled.
     compiler_fence(Ordering::SeqCst);
-    crate::asm::irq_enable();
+    // Safety: as per outer function
+    unsafe {
+        crate::asm::irq_enable();
+    }
 }
 
 /// Disable IRQ


### PR DESCRIPTION
Fixes #103