### PR TITLE
Move the link_section attr to other examples.

### DIFF
--- a/examples/mps3-an536/src/bin/gic-unified-irq.rs
+++ b/examples/mps3-an536/src/bin/gic-unified-irq.rs
@@ -92,7 +92,9 @@ fn dump_cpsr() {
     println!("CPSR: {:?}", cpsr);
 }
 
+// The `link_section` is just to check the macro can cope with it
 #[irq]
+#[unsafe(link_section = ".text.some_other_section")]
 fn irq_handler() {
     println!("> IRQ");
     while let Some(int_id) = GicCpuInterface::get_and_acknowledge_interrupt(InterruptGroup::Group1)

--- a/examples/mps3-an536/src/bin/prefetch-exception-a32.rs
+++ b/examples/mps3-an536/src/bin/prefetch-exception-a32.rs
@@ -51,7 +51,6 @@ core::arch::global_asm!(
 
 // Custom link sections are allowed as well.
 #[exception(Undefined)]
-#[unsafe(link_section = ".text._rust_undefined_handler")]
 fn undefined_handler(_addr: usize) -> ! {
     panic!("unexpected undefined exception");
 }

--- a/examples/versatileab/src/bin/interrupt.rs
+++ b/examples/versatileab/src/bin/interrupt.rs
@@ -94,7 +94,10 @@ fn catchall_handler() {
 }
 
 /// Our IRQ handler asks the PL190 what to do, and does it.
+///
+/// The `link_section` is just to check the macro can cope with it
 #[exception(Irq)]
+#[unsafe(link_section = ".text.some_other_section")]
 unsafe fn interrupt_handler() {
     println!("> interrupt_handler()");
     PL190.irq_process();


### PR DESCRIPTION
I wanted to keep the A32/T32 examples as similar to each other as possible, so I moved the link_section attr over to some interrupt examples instead. One uses `[exception(Irq)]` and one uses `[irq]`, so we know both work.