### PR TITLE
Report stack usage

### DIFF
--- a/aarch32-cpu/src/lib.rs
+++ b/aarch32-cpu/src/lib.rs
@@ -25,6 +25,8 @@ pub mod cache;
 pub mod interrupt;
 pub mod mmu;
 pub mod register;
+#[cfg(target_arch = "arm")]
+pub mod stacks;
 
 #[cfg(any(test, doc, arm_architecture = "v7-r"))]
 pub mod pmsav7;

--- a/aarch32-cpu/src/stacks.rs
+++ b/aarch32-cpu/src/stacks.rs
@@ -1,0 +1,64 @@
+//! Code for checking stack usage
+
+/// Reports stack usage as a count of bytes
+///
+/// It starts at the lower bound, and looks for values that are set to 0,
+/// concluding that those values have never been used. It returns `(total,
+/// used)` in bytes.
+///
+/// # Safety
+///
+/// Pass a range of valid, readable, memory with 32-bit aligned addresses.
+pub unsafe fn stack_used_bytes(stack: core::ops::Range<*const u32>) -> (usize, usize) {
+    let start = stack.start;
+    let end: *const u32 = stack.end;
+    let size_words = unsafe { end.offset_from_unsigned(start) };
+    let free_words = unsafe { stack_used_bytes_asm(start, size_words) };
+    let used_words = size_words - free_words;
+    (
+        size_words * core::mem::size_of::<u32>(),
+        used_words * core::mem::size_of::<u32>(),
+    )
+}
+
+/// Counts number of words that are equal to zero
+///
+/// Written in Arm assembly to avoid any issues with pointing at things that are
+/// not validly initialised integers (as far as Rust is concerned).
+///
+/// Returns a count of the number of words equal to 0x0 at `start`, with a
+/// maximum of `size` words
+///
+/// # Safety
+///
+/// The address `start` must be 32-bit aligned, and point to a region of memory
+/// of at least `size` words in length.
+unsafe fn stack_used_bytes_asm(start: *const u32, size: usize) -> usize {
+    let result: usize;
+    core::arch::asm!(
+        r#"
+        // skip out if size is zero
+        movs    {result}, #0
+        cmp     {size}, #0
+        beq     3f
+2:      // loop
+        ldr     {scratch}, [{start}]
+        cmp     {scratch}, #0
+        // break out if value is non-zero
+        bne     3f
+        // otherwise increment counter
+        adds    {result}, {result}, #1
+        adds    {start}, {start}, #4
+        // loop if not finished yet
+        cmp     {result}, {size}
+        bne     2b
+        // all finished
+3:
+        "#,
+        size = in(reg) size,
+        start = in(reg) start,
+        result = out(reg) result,
+        scratch = out(reg) _,
+    );
+    result
+}

--- a/aarch32-cpu/src/stacks.rs
+++ b/aarch32-cpu/src/stacks.rs
@@ -10,10 +10,8 @@
 ///
 /// Pass a range of valid, readable, memory with 32-bit aligned addresses.
 pub unsafe fn stack_used_bytes(stack: core::ops::Range<*const u32>) -> (usize, usize) {
-    let start = stack.start;
-    let end: *const u32 = stack.end;
-    let size_words = unsafe { end.offset_from_unsigned(start) };
-    let free_words = unsafe { stack_used_bytes_asm(start, size_words) };
+    let size_words = unsafe { stack.end.offset_from(stack.start) } as usize;
+    let free_words = unsafe { stack_used_bytes_asm(stack.start, size_words) };
     let used_words = size_words - free_words;
     (
         size_words * core::mem::size_of::<u32>(),

--- a/examples/mps3-an536/memory.x
+++ b/examples/mps3-an536/memory.x
@@ -6,13 +6,14 @@ See https://github.com/qemu/qemu/blob/master/hw/arm/mps3r.c
 
 MEMORY {
     QSPI : ORIGIN = 0x08000000, LENGTH = 8M
-    DDR  : ORIGIN = 0x20000000, LENGTH = 128M
+    BRAM : ORIGIN = 0x10000000, LENGTH = 512K
+    DDR  : ORIGIN = 0x20000000, LENGTH = 1536M
 }
 
 REGION_ALIAS("VECTORS", QSPI);
 REGION_ALIAS("CODE", QSPI);
-REGION_ALIAS("DATA", DDR);
-REGION_ALIAS("STACKS", DDR);
+REGION_ALIAS("DATA", BRAM);
+REGION_ALIAS("STACKS", BRAM);
 
 SECTIONS {
     /* ### Interrupt Handler Entries
@@ -34,10 +35,10 @@ SECTIONS {
 } INSERT AFTER .text;
 
 
-PROVIDE(_hyp_stack_size = 1M);
-PROVIDE(_und_stack_size = 1M);
-PROVIDE(_svc_stack_size = 1M);
-PROVIDE(_abt_stack_size = 1M);
-PROVIDE(_irq_stack_size = 1M);
-PROVIDE(_fiq_stack_size = 1M);
-PROVIDE(_sys_stack_size = 1M);
+PROVIDE(_hyp_stack_size = 16K);
+PROVIDE(_und_stack_size = 16K);
+PROVIDE(_svc_stack_size = 16K);
+PROVIDE(_abt_stack_size = 16K);
+PROVIDE(_irq_stack_size = 64);
+PROVIDE(_fiq_stack_size = 64);
+PROVIDE(_sys_stack_size = 16K);

--- a/examples/mps3-an536/src/bin/abt-exception-t32.rs
+++ b/examples/mps3-an536/src/bin/abt-exception-t32.rs
@@ -28,9 +28,13 @@ fn main() -> ! {
         unaligned_from_t32();
     }
 
+    // turn it off before we do the stack dump on exit, because println! has been
+    // observed to do unaligned reads.
+    disable_alignment_check();
+
     println!("Recovered from fault OK!");
 
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }
 
 // These functions are written in assembly
@@ -97,6 +101,7 @@ unsafe fn data_abort_handler(addr: usize) -> usize {
             "Bad fault address {:08x} is not {:08x}",
             addr, expect_fault_at
         );
+        semihosting::process::abort();
     }
 
     let expect_fault_from = core::ptr::addr_of!(COUNTER) as usize + 1;
@@ -108,6 +113,7 @@ unsafe fn data_abort_handler(addr: usize) -> usize {
             "Bad DFAR address {:08x} is not {:08x}",
             dfar.0, expect_fault_from
         );
+        semihosting::process::abort();
     }
 
     match COUNTER.fetch_add(1, Ordering::Relaxed) {

--- a/examples/mps3-an536/src/bin/fpu-test.rs
+++ b/examples/mps3-an536/src/bin/fpu-test.rs
@@ -32,5 +32,5 @@ fn main() -> ! {
         let bar_len = ((sine + 1.0) * (f64::from(MAX_LEN) / 2.0)) as usize;
         println!("({:7.04}) {:.*}o", sine, bar_len, BAR);
     }
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }

--- a/examples/mps3-an536/src/bin/generic_timer.rs
+++ b/examples/mps3-an536/src/bin/generic_timer.rs
@@ -55,5 +55,5 @@ fn main() -> ! {
         println!("{} countdown hit zero!", name,);
     }
 
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }

--- a/examples/mps3-an536/src/bin/generic_timer_irq.rs
+++ b/examples/mps3-an536/src/bin/generic_timer_irq.rs
@@ -58,7 +58,7 @@ fn main() -> ! {
 
         if count == 10 {
             println!("Timer IRQ test completed OK");
-            semihosting::process::exit(0);
+            mps3_an536::exit(0);
         }
     }
 }

--- a/examples/mps3-an536/src/bin/gic-map.rs
+++ b/examples/mps3-an536/src/bin/gic-map.rs
@@ -106,7 +106,7 @@ fn main() -> ! {
 
     println!("IRQ test completed OK");
 
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }
 
 fn dump_sctlr() {

--- a/examples/mps3-an536/src/bin/gic-priority-ceiling.rs
+++ b/examples/mps3-an536/src/bin/gic-priority-ceiling.rs
@@ -87,7 +87,7 @@ fn main() -> ! {
 
     println!("IRQ test completed OK");
 
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }
 
 fn dump_sctlr() {

--- a/examples/mps3-an536/src/bin/gic-static-section-irq.rs
+++ b/examples/mps3-an536/src/bin/gic-static-section-irq.rs
@@ -84,7 +84,7 @@ fn main() -> ! {
 
     println!("IRQ test completed OK");
 
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }
 
 fn dump_sctlr() {

--- a/examples/mps3-an536/src/bin/gic-unified-irq.rs
+++ b/examples/mps3-an536/src/bin/gic-unified-irq.rs
@@ -84,7 +84,7 @@ fn main() -> ! {
 
     println!("IRQ test completed OK");
 
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }
 
 fn dump_sctlr() {

--- a/examples/mps3-an536/src/bin/prefetch-exception-a32.rs
+++ b/examples/mps3-an536/src/bin/prefetch-exception-a32.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
 
     println!("Recovered from fault OK!");
 
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }
 
 // These functions are written in assembly

--- a/examples/mps3-an536/src/bin/prefetch-exception-t32.rs
+++ b/examples/mps3-an536/src/bin/prefetch-exception-t32.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
 
     println!("Recovered from fault OK!");
 
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }
 
 // These functions are written in assembly

--- a/examples/mps3-an536/src/bin/registers.rs
+++ b/examples/mps3-an536/src/bin/registers.rs
@@ -18,7 +18,7 @@ fn main() -> ! {
     #[cfg(arm_architecture = "v8-r")]
     mpu_pmsa_v8();
     test_changing_sctlr();
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }
 
 fn chip_info() {

--- a/examples/mps3-an536/src/bin/smp_test.rs
+++ b/examples/mps3-an536/src/bin/smp_test.rs
@@ -84,7 +84,7 @@ fn main() -> ! {
         if counter == CORE0_WILL_WAIT {
             println!("CPU 1 is missing?!");
 
-            semihosting::process::exit(0);
+            mps3_an536::exit(0);
         }
     }
 
@@ -125,7 +125,7 @@ fn main() -> ! {
         code = 1;
     }
 
-    semihosting::process::exit(code);
+    mps3_an536::exit(code);
 }
 
 /// The entry-point to the Rust application.

--- a/examples/mps3-an536/src/bin/smp_test.rs
+++ b/examples/mps3-an536/src/bin/smp_test.rs
@@ -39,7 +39,7 @@ impl<const LEN_BYTES: usize> Stack<LEN_BYTES> {
 
 unsafe impl<const LEN_BYTES: usize> Sync for Stack<LEN_BYTES> {}
 
-static CORE1_STACK: Stack<{ 8 * 1024 * 1024 }> = Stack::new();
+static CORE1_STACK: Stack<{ 256 * 1024 }> = Stack::new();
 
 static CORE1_BOOTED: AtomicBool = AtomicBool::new(false);
 

--- a/examples/mps3-an536/src/bin/svc-a32.rs
+++ b/examples/mps3-an536/src/bin/svc-a32.rs
@@ -18,7 +18,7 @@ fn main() -> ! {
     println!("x = {}, y = {}, z = {:0.3}", x, y, z);
     do_svc1();
     println!("x = {}, y = {}, z = {:0.3}", x, y, z);
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }
 
 /// This is our SVC exception handler

--- a/examples/mps3-an536/src/bin/svc-t32.rs
+++ b/examples/mps3-an536/src/bin/svc-t32.rs
@@ -20,7 +20,7 @@ fn main() -> ! {
         svc12_from_t32();
     }
     println!("x = {}, y = {}, z = {:0.3}", x, y, z);
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }
 
 /// This is our SVC exception handler

--- a/examples/mps3-an536/src/bin/undef-exception-a32.rs
+++ b/examples/mps3-an536/src/bin/undef-exception-a32.rs
@@ -25,7 +25,7 @@ fn main() -> ! {
 
     println!("Recovered from fault OK!");
 
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }
 
 // These functions are written in assembly

--- a/examples/mps3-an536/src/bin/undef-exception-t32.rs
+++ b/examples/mps3-an536/src/bin/undef-exception-t32.rs
@@ -25,7 +25,7 @@ fn main() -> ! {
 
     println!("Recovered from fault OK!");
 
-    semihosting::process::exit(0);
+    mps3_an536::exit(0);
 }
 
 // These functions are written in assembly

--- a/examples/mps3-an536/src/lib.rs
+++ b/examples/mps3-an536/src/lib.rs
@@ -75,15 +75,86 @@ static WANT_PANIC: AtomicBool = AtomicBool::new(false);
 fn panic(info: &core::panic::PanicInfo) -> ! {
     semihosting::println!("PANIC: {:#?}", info);
     if WANT_PANIC.load(Ordering::Relaxed) {
-        semihosting::process::exit(0);
+        exit(0);
     } else {
-        semihosting::process::abort();
+        exit(1);
     }
 }
 
 /// Set the panic function as no longer returning a failure code via semihosting
 pub fn want_panic() {
     WANT_PANIC.store(true, Ordering::Relaxed);
+}
+
+/// Exit from QEMU with code
+pub fn exit(code: i32) -> ! {
+    stack_dump();
+    semihosting::process::exit(code)
+}
+
+/// Print stack using to semihosting output for each stack
+///
+/// Produces output like:
+///
+/// ```text
+/// Stack usage report:
+/// SYS Stack =    332 used of  16384 bytes (002%) @ 0x1006bf80..0x1006ff80
+/// FIQ Stack =      0 used of     64 bytes (000%) @ 0x1006ff80..0x1006ffc0
+/// IRQ Stack =      0 used of     64 bytes (000%) @ 0x1006ffc0..0x10070000
+/// ABT Stack =      0 used of  16384 bytes (000%) @ 0x10070000..0x10074000
+/// SVC Stack =      0 used of  16384 bytes (000%) @ 0x10074000..0x10078000
+/// UND Stack =    244 used of  16384 bytes (001%) @ 0x10078000..0x1007c000
+/// HYP Stack =      0 used of  16384 bytes (000%) @ 0x1007c000..0x10080000
+/// ```
+fn stack_dump() {
+    use aarch32_cpu::stacks::stack_used_bytes;
+    use core::ptr::addr_of;
+
+    extern "C" {
+        static _sys_stack_end: u32;
+        static _sys_stack: u32;
+        static _fiq_stack_end: u32;
+        static _fiq_stack: u32;
+        static _irq_stack_end: u32;
+        static _irq_stack: u32;
+        static _abt_stack_end: u32;
+        static _abt_stack: u32;
+        static _svc_stack_end: u32;
+        static _svc_stack: u32;
+        static _und_stack_end: u32;
+        static _und_stack: u32;
+        static _hyp_stack_end: u32;
+        static _hyp_stack: u32;
+    }
+
+    // these are placed in the order they are in aarch32-rt/link.x
+    let stacks = [
+        ("SYS", addr_of!(_sys_stack_end)..addr_of!(_sys_stack)),
+        ("FIQ", addr_of!(_fiq_stack_end)..addr_of!(_fiq_stack)),
+        ("IRQ", addr_of!(_irq_stack_end)..addr_of!(_irq_stack)),
+        ("ABT", addr_of!(_abt_stack_end)..addr_of!(_abt_stack)),
+        ("SVC", addr_of!(_svc_stack_end)..addr_of!(_svc_stack)),
+        ("UND", addr_of!(_und_stack_end)..addr_of!(_und_stack)),
+        ("HYP", addr_of!(_hyp_stack_end)..addr_of!(_hyp_stack)),
+    ];
+
+    semihosting::eprintln!("Stack usage report:");
+
+    unsafe {
+        for (name, range) in stacks {
+            let (total, used) = stack_used_bytes(range.clone());
+            let percent = used * 100 / total;
+            // Send to stderr, so it doesn't mix with expected output on stdout
+            semihosting::eprintln!(
+                "{} Stack = {:6} used of {:6} bytes ({:03}%) @ {:08x?}",
+                name,
+                used,
+                total,
+                percent,
+                range
+            );
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/examples/versatileab/memory.x
+++ b/examples/versatileab/memory.x
@@ -13,10 +13,10 @@ REGION_ALIAS("CODE", SDRAM);
 REGION_ALIAS("DATA", SDRAM);
 REGION_ALIAS("STACKS", SDRAM);
 
-PROVIDE(_hyp_stack_size = 1M);
-PROVIDE(_und_stack_size = 1M);
-PROVIDE(_svc_stack_size = 1M);
-PROVIDE(_abt_stack_size = 1M);
-PROVIDE(_irq_stack_size = 1M);
-PROVIDE(_fiq_stack_size = 1M);
-PROVIDE(_sys_stack_size = 1M);
+PROVIDE(_hyp_stack_size = 16K);
+PROVIDE(_und_stack_size = 16K);
+PROVIDE(_svc_stack_size = 16K);
+PROVIDE(_abt_stack_size = 16K);
+PROVIDE(_irq_stack_size = 64);
+PROVIDE(_fiq_stack_size = 64);
+PROVIDE(_sys_stack_size = 16K);

--- a/examples/versatileab/src/bin/abt-exception-a32.rs
+++ b/examples/versatileab/src/bin/abt-exception-a32.rs
@@ -28,9 +28,13 @@ fn main() -> ! {
         unaligned_from_a32();
     }
 
+    // turn it off before we do the stack dump on exit, because println! has been
+    // observed to do unaligned reads.
+    disable_alignment_check();
+
     println!("Recovered from fault OK!");
 
-    semihosting::process::exit(0);
+    versatileab::exit(0);
 }
 
 // These functions are written in assembly

--- a/examples/versatileab/src/bin/abt-exception-t32.rs
+++ b/examples/versatileab/src/bin/abt-exception-t32.rs
@@ -28,9 +28,13 @@ fn main() -> ! {
         unaligned_from_t32();
     }
 
+    // turn it off before we do the stack dump on exit, because println! has been
+    // observed to do unaligned reads.
+    disable_alignment_check();
+
     println!("Recovered from fault OK!");
 
-    semihosting::process::exit(0);
+    versatileab::exit(0);
 }
 
 // These functions are written in assembly

--- a/examples/versatileab/src/bin/fpu-test.rs
+++ b/examples/versatileab/src/bin/fpu-test.rs
@@ -32,5 +32,5 @@ fn main() -> ! {
         let bar_len = ((sine + 1.0) * (f64::from(MAX_LEN) / 2.0)) as usize;
         println!("({:7.04}) {:.*}o", sine, bar_len, BAR);
     }
-    semihosting::process::exit(0);
+    versatileab::exit(0);
 }

--- a/examples/versatileab/src/bin/interrupt.rs
+++ b/examples/versatileab/src/bin/interrupt.rs
@@ -58,12 +58,12 @@ fn my_main() -> ! {
     for _ in 0..1_000 {
         if MARKER.load(SeqCst) == 2 {
             println!("catch all works. All done!");
-            semihosting::process::exit(0);
+            versatileab::exit(0);
         }
     }
 
     println!("Not interrupted!?");
-    semihosting::process::exit(1);
+    versatileab::exit(1);
 }
 
 /// Our low-prio handler re-enables interrupts and triggers a second,

--- a/examples/versatileab/src/bin/prefetch-exception-a32.rs
+++ b/examples/versatileab/src/bin/prefetch-exception-a32.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
 
     println!("Recovered from fault OK!");
 
-    semihosting::process::exit(0);
+    versatileab::exit(0);
 }
 
 // These functions are written in assembly

--- a/examples/versatileab/src/bin/prefetch-exception-t32.rs
+++ b/examples/versatileab/src/bin/prefetch-exception-t32.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
 
     println!("Recovered from fault OK!");
 
-    semihosting::process::exit(0);
+    versatileab::exit(0);
 }
 
 // These functions are written in assembly

--- a/examples/versatileab/src/bin/registers.rs
+++ b/examples/versatileab/src/bin/registers.rs
@@ -16,7 +16,7 @@ fn main() -> ! {
     test_changing_sctlr();
     #[cfg(arm_architecture = "v7-r")]
     mpu_pmsa_v7();
-    semihosting::process::exit(0);
+    versatileab::exit(0);
 }
 
 fn chip_info() {

--- a/examples/versatileab/src/bin/svc-a32.rs
+++ b/examples/versatileab/src/bin/svc-a32.rs
@@ -18,7 +18,7 @@ fn main() -> ! {
     println!("x = {}, y = {}, z = {:0.3}", x, y, z);
     do_svc1();
     println!("x = {}, y = {}, z = {:0.3}", x, y, z);
-    semihosting::process::exit(0);
+    versatileab::exit(0);
 }
 
 /// This is our SVC exception handler

--- a/examples/versatileab/src/bin/svc-t32.rs
+++ b/examples/versatileab/src/bin/svc-t32.rs
@@ -20,7 +20,7 @@ fn main() -> ! {
         svc12_from_t32();
     }
     println!("x = {}, y = {}, z = {:0.3}", x, y, z);
-    semihosting::process::exit(0);
+    versatileab::exit(0);
 }
 
 /// This is our SVC exception handler

--- a/examples/versatileab/src/bin/undef-exception-a32.rs
+++ b/examples/versatileab/src/bin/undef-exception-a32.rs
@@ -25,7 +25,7 @@ fn main() -> ! {
 
     println!("Recovered from fault OK!");
 
-    semihosting::process::exit(0);
+    versatileab::exit(0);
 }
 
 // These functions are written in assembly

--- a/examples/versatileab/src/bin/undef-exception-t32.rs
+++ b/examples/versatileab/src/bin/undef-exception-t32.rs
@@ -25,7 +25,7 @@ fn main() -> ! {
 
     println!("Recovered from fault OK!");
 
-    semihosting::process::exit(0);
+    versatileab::exit(0);
 }
 
 // These functions are written in assembly

--- a/examples/versatileab/src/lib.rs
+++ b/examples/versatileab/src/lib.rs
@@ -29,3 +29,74 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 pub fn want_panic() {
     WANT_PANIC.store(true, portable_atomic::Ordering::Relaxed);
 }
+
+/// Exit from QEMU with code
+pub fn exit(code: i32) -> ! {
+    stack_dump();
+    semihosting::process::exit(code)
+}
+
+/// Print stack using to semihosting output for each stack
+///
+/// Produces output like:
+///
+/// ```text
+/// Stack usage report:
+/// SYS Stack =    332 used of  16384 bytes (002%) @ 0x1006bf80..0x1006ff80
+/// FIQ Stack =      0 used of     64 bytes (000%) @ 0x1006ff80..0x1006ffc0
+/// IRQ Stack =      0 used of     64 bytes (000%) @ 0x1006ffc0..0x10070000
+/// ABT Stack =      0 used of  16384 bytes (000%) @ 0x10070000..0x10074000
+/// SVC Stack =      0 used of  16384 bytes (000%) @ 0x10074000..0x10078000
+/// UND Stack =    244 used of  16384 bytes (001%) @ 0x10078000..0x1007c000
+/// HYP Stack =      0 used of  16384 bytes (000%) @ 0x1007c000..0x10080000
+/// ```
+fn stack_dump() {
+    use aarch32_cpu::stacks::stack_used_bytes;
+    use core::ptr::addr_of;
+
+    extern "C" {
+        static _sys_stack_end: u32;
+        static _sys_stack: u32;
+        static _fiq_stack_end: u32;
+        static _fiq_stack: u32;
+        static _irq_stack_end: u32;
+        static _irq_stack: u32;
+        static _abt_stack_end: u32;
+        static _abt_stack: u32;
+        static _svc_stack_end: u32;
+        static _svc_stack: u32;
+        static _und_stack_end: u32;
+        static _und_stack: u32;
+        static _hyp_stack_end: u32;
+        static _hyp_stack: u32;
+    }
+
+    // these are placed in the order they are in aarch32-rt/link.x
+    let stacks = [
+        ("SYS", addr_of!(_sys_stack_end)..addr_of!(_sys_stack)),
+        ("FIQ", addr_of!(_fiq_stack_end)..addr_of!(_fiq_stack)),
+        ("IRQ", addr_of!(_irq_stack_end)..addr_of!(_irq_stack)),
+        ("ABT", addr_of!(_abt_stack_end)..addr_of!(_abt_stack)),
+        ("SVC", addr_of!(_svc_stack_end)..addr_of!(_svc_stack)),
+        ("UND", addr_of!(_und_stack_end)..addr_of!(_und_stack)),
+        ("HYP", addr_of!(_hyp_stack_end)..addr_of!(_hyp_stack)),
+    ];
+
+    semihosting::eprintln!("Stack usage report:");
+
+    unsafe {
+        for (name, range) in stacks {
+            let (total, used) = stack_used_bytes(range.clone());
+            let percent = used * 100 / total;
+            // Send to stderr, so it doesn't mix with expected output on stdout
+            semihosting::eprintln!(
+                "{} Stack = {:6} used of {:6} bytes ({:03}%) @ {:08x?}",
+                name,
+                used,
+                total,
+                percent,
+                range
+            );
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@
 export RUSTC_BOOTSTRAP := "1"
 
 
-# If you run with `just v=1` then we make cargo run in verbose mode
+# If you run with `just --set v 1` then we make cargo run in verbose mode
 v := "0"
 verbose := if v == "1" { "--verbose" } else { "" }
 


### PR DESCRIPTION
Add some helper functions for checking stack usage, and add stack usage reports to the examples. I also took the opportunity to massively reduce the stack sizes, now we know exactly how much space we need.

The report goes to stderr because it may change as Rust versions change, and so we don't want it to appear in the reference outputs.

This relies on QEMU initialising RAM with 0x0, which it does. Users on real hardware would need to paint their stack for this to work.
