### PR TITLE
Update docs

### DIFF
--- a/examples/mps3-an536/Cargo.toml
+++ b/examples/mps3-an536/Cargo.toml
@@ -5,14 +5,13 @@ authors = [
 ]
 default-run = "hello"
 description = "Examples for MPS3-AN536 device (Arm Cortex-R52)"
-edition = "2021"
+edition = "2024"
 homepage = "https://github.com/rust-embedded/aarch32"
 license = "MIT OR Apache-2.0"
 name = "mps3-an536"
 publish = false
 readme = "README.md"
 repository = "https://github.com/rust-embedded/aarch32.git"
-rust-version = "1.83"
 version = "0.0.0"
 
 [dependencies]

--- a/examples/mps3-an536/README.md
+++ b/examples/mps3-an536/README.md
@@ -1,29 +1,84 @@
 # Examples for Arm MPS3-AN536
 
-This package contains example binaries for the Arm MPS3-AN536 evaluation
-system, featuring one or two Arm Cortex-R52 processor cores. This crate
-should be compiled for the `armv8r-none-eabihf` target. The repo-level
-[`.cargo/config.toml`] will ensure the code runs on the appropriate QEMU
-configuration.
+This package contains example binaries for the Arm MPS3-AN536 evaluation system,
+featuring one or two Arm Cortex-R52 processor cores. This crate is tested on the
+following targets:
 
-As of Rust 1.87, `armv8r-none-eabihf` is a Tier 3 target and so these examples
-require Nightly Rust.
+- `armv8r-none-eabihf` - ARMv8-R AArch32, hard-float, Arm mode
+- `thumbv8r-none-eabihf` - ARMv8-R AArch32, hard-float, Thumb mode
+
+The repo-level [`.cargo/config.toml`] will ensure the code runs on the
+appropriate QEMU configuration.
+
+As of Rust 1.92, `armv8r-none-eabihf` is a Tier 2 target and so any stable
+release from 1.92 or newer should work for that target. However,
+`thumbv8r-none-eabihf` is still a Tier 3 target, which means Nightly Rust is
+required. This folder contains a [`rust-toolchain.toml`] which pins us to a
+specific release of nightly that is known to work.
 
 We have only tested this crate on `qemu-system-arm` emulating the Arm
 MPS3-AN536, not the real thing.
 
 [`.cargo/config.toml`]: ../../.cargo/config.toml
+[`rust-toolchain.toml`]: ./rust-toolchain.toml
+
+## Running
+
+Run these examples as follows:
+
+```console
+$ cargo run --bin hello
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
+     Running `qemu-system-arm -machine mps3-an536 -cpu cortex-r52 -semihosting -nographic -audio none -kernel target/armv8r-none-eabihf/debug/hello`
+Hello, this is semihosting! x = 1.000, y = 2.000
+PANIC: PanicInfo {
+    message: I am an example panic,
+    location: Location {
+        file: "src/bin/hello.rs",
+        line: 20,
+        column: 5,
+    },
+    can_unwind: true,
+    force_no_backtrace: false,
+}
+$ cargo run --bin hello --target thumbv8r-none-eabihf -Zbuild-std=core
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.92s
+     Running `qemu-system-arm -machine mps3-an536 -cpu cortex-r52 -semihosting -nographic -audio none -kernel target/thumbv8r-none-eabihf/debug/hello`
+Hello, this is semihosting! x = 1.000, y = 2.000
+PANIC: PanicInfo {
+    message: I am an example panic,
+    location: Location {
+        file: "src/bin/hello.rs",
+        line: 20,
+        column: 5,
+    },
+    can_unwind: true,
+    force_no_backtrace: false,
+}
+```
+
+## Debugging
+
+You can start a GDB server by adding `-- -s -S` to the end of the `cargo run`
+command, and the connect with GDB as follows:
+
+```console
+$ cargo run --bin hello -- -s -S
+# QEMU runs and hangs waiting for a connection. In another terminal run:
+$ arm-none-eabi-gdb -x commands.gdb target/armv8r-none-eabihf/debug/hello
+# GDB will start and connect to QEMU's GDB server. The commands.gdb file sets up some useful defaults.
+```
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.83.0 and up, as recorded
-by the `package.rust-version` property in `Cargo.toml`. These examples are
-not version controlled and we may change the MSRV at any time.
+These examples are guaranteed to compile on the version of Rust given in the
+[`rust-toolchain.toml`] file. These examples are not version controlled and we
+may change the MSRV at any time.
 
 ## Licence
 
-* Copyright (c) Ferrous Systems
-* Copyright (c) The Rust Embedded Devices Working Group developers
+- Copyright (c) Ferrous Systems
+- Copyright (c) The Rust Embedded Devices Working Group developers
 
 Licensed under either [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at
 your option.

--- a/examples/mps3-an536/commands.gdb
+++ b/examples/mps3-an536/commands.gdb
@@ -8,4 +8,6 @@ break _asm_irq_handler
 break _asm_fiq_handler
 layout asm
 layout regs
+set logging file ./target/debug.log
+set logging enabled on
 stepi

--- a/examples/mps3-an536/src/bin/abt-exception-a32.rs
+++ b/examples/mps3-an536/src/bin/abt-exception-a32.rs
@@ -10,7 +10,7 @@ use aarch32_rt::{entry, exception};
 use mps3_an536 as _;
 use semihosting::println;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 static COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// The entry-point to the Rust application.
@@ -34,7 +34,7 @@ fn main() -> ! {
 }
 
 // These functions are written in assembly
-extern "C" {
+unsafe extern "C" {
     fn unaligned_from_a32();
 }
 

--- a/examples/mps3-an536/src/bin/abt-exception-t32.rs
+++ b/examples/mps3-an536/src/bin/abt-exception-t32.rs
@@ -10,7 +10,7 @@ use aarch32_rt::{entry, exception};
 use mps3_an536 as _;
 use semihosting::println;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 static COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// The entry-point to the Rust application.
@@ -34,7 +34,7 @@ fn main() -> ! {
 }
 
 // These functions are written in assembly
-extern "C" {
+unsafe extern "C" {
     fn unaligned_from_t32();
 }
 

--- a/examples/mps3-an536/src/bin/gic-map.rs
+++ b/examples/mps3-an536/src/bin/gic-map.rs
@@ -9,8 +9,8 @@ use core::cell::RefCell;
 
 use aarch32_rt::{entry, irq};
 use arm_gic::{
-    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
     IntId,
+    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
 };
 use heapless::linear_map::LinearMap;
 use mps3_an536::InterruptHandler;

--- a/examples/mps3-an536/src/bin/gic-priority-ceiling.rs
+++ b/examples/mps3-an536/src/bin/gic-priority-ceiling.rs
@@ -5,8 +5,8 @@
 
 use aarch32_rt::{entry, irq};
 use arm_gic::{
-    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
     IntId,
+    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
 };
 use mps3_an536 as _;
 use semihosting::println;

--- a/examples/mps3-an536/src/bin/gic-static-section-irq.rs
+++ b/examples/mps3-an536/src/bin/gic-static-section-irq.rs
@@ -138,7 +138,7 @@ fn irq_handler() {
         }
         // handle the interrupt
         println!("- handle_interrupt_with_id({:?})", next_int_id);
-        extern "Rust" {
+        unsafe extern "Rust" {
             static __irq_entries_start: InterruptHandler;
             static __irq_entries_end: InterruptHandler;
         }

--- a/examples/mps3-an536/src/bin/gic-static-section-irq.rs
+++ b/examples/mps3-an536/src/bin/gic-static-section-irq.rs
@@ -7,8 +7,8 @@
 
 use aarch32_rt::{entry, irq};
 use arm_gic::{
-    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
     IntId,
+    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
 };
 use mps3_an536::InterruptHandler;
 use semihosting::println;

--- a/examples/mps3-an536/src/bin/gic-unified-irq.rs
+++ b/examples/mps3-an536/src/bin/gic-unified-irq.rs
@@ -7,8 +7,8 @@
 
 use aarch32_rt::{entry, irq};
 use arm_gic::{
-    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
     IntId,
+    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
 };
 use mps3_an536 as _;
 use semihosting::println;

--- a/examples/mps3-an536/src/bin/prefetch-exception-a32.rs
+++ b/examples/mps3-an536/src/bin/prefetch-exception-a32.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
 }
 
 // These functions are written in assembly
-extern "C" {
+unsafe extern "C" {
     fn bkpt_from_a32();
 }
 

--- a/examples/mps3-an536/src/bin/prefetch-exception-t32.rs
+++ b/examples/mps3-an536/src/bin/prefetch-exception-t32.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
 }
 
 // These functions are written in assembly
-extern "C" {
+unsafe extern "C" {
     fn bkpt_from_t32();
 }
 

--- a/examples/mps3-an536/src/bin/smp_test.rs
+++ b/examples/mps3-an536/src/bin/smp_test.rs
@@ -13,7 +13,7 @@
 use core::cell::{RefCell, UnsafeCell};
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
-use aarch32_cpu::register::{cpsr::ProcessorMode, Cpsr, Hactlr, Sctlr};
+use aarch32_cpu::register::{Cpsr, Hactlr, Sctlr, cpsr::ProcessorMode};
 use aarch32_rt::entry;
 use semihosting::println;
 

--- a/examples/mps3-an536/src/bin/smp_test.rs
+++ b/examples/mps3-an536/src/bin/smp_test.rs
@@ -63,7 +63,7 @@ const CS_MUTEX_LOOPS: u32 = 1000;
 #[entry]
 fn main() -> ! {
     let fpga_led = 0xE020_2000 as *mut u32;
-    extern "C" {
+    unsafe extern "C" {
         static mut _core1_stack_pointer: usize;
     }
     unsafe {
@@ -131,7 +131,7 @@ fn main() -> ! {
 /// The entry-point to the Rust application.
 ///
 /// It is called by the start-up code below, on Core 1.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn kmain2() {
     CORE1_BOOTED.store(true, Ordering::SeqCst);
 

--- a/examples/mps3-an536/src/bin/svc-t32.rs
+++ b/examples/mps3-an536/src/bin/svc-t32.rs
@@ -16,9 +16,7 @@ fn main() -> ! {
     let y = x + 1;
     let z = (y as f64) * 1.5;
     println!("x = {}, y = {}, z = {:0.3}", x, y, z);
-    unsafe {
-        svc12_from_t32();
-    }
+    do_svc1();
     println!("x = {}, y = {}, z = {:0.3}", x, y, z);
     semihosting::process::exit(0);
 }
@@ -29,38 +27,16 @@ fn svc_handler(arg: u32) {
     println!("In svc_handler, with arg=0x{:06x}", arg);
     if arg == 0x12 {
         // test nested SVC calls
-        unsafe {
-            svc34_from_t32();
-        }
+        do_svc2();
     }
 }
 
-// These functions are written in assembly
-extern "C" {
-    fn svc12_from_t32();
-    fn svc34_from_t32();
+#[instruction_set(arm::t32)]
+fn do_svc1() {
+    aarch32_cpu::svc!(0x12);
 }
 
-core::arch::global_asm!(
-    r#"
-    // fn svc12_from_t32();
-    .thumb
-    .global svc12_from_t32
-    .type svc12_from_t32, %function
-    svc12_from_t32:
-        push    {{ r7, lr }}
-        svc     0x12
-        pop     {{ r7, pc }}
-    .size svc12_from_t32, . - svc12_from_t32
-
-    // fn svc34_from_t32();
-    .thumb
-    .global svc34_from_t32
-    .type svc34_from_t32, %function
-    svc34_from_t32:
-        push    {{ r7, lr }}
-        svc     0x34
-        pop     {{ r7, pc }}
-    .size svc34_from_t32, . - svc34_from_t32
-"#
-);
+#[instruction_set(arm::t32)]
+fn do_svc2() {
+    aarch32_cpu::svc!(0x34);
+}

--- a/examples/mps3-an536/src/bin/undef-exception-a32.rs
+++ b/examples/mps3-an536/src/bin/undef-exception-a32.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
 }
 
 // These functions are written in assembly
-extern "C" {
+unsafe extern "C" {
     fn udf_from_a32();
 }
 

--- a/examples/mps3-an536/src/bin/undef-exception-t32.rs
+++ b/examples/mps3-an536/src/bin/undef-exception-t32.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
 }
 
 // These functions are written in assembly
-extern "C" {
+unsafe extern "C" {
     fn udf_from_t32();
 }
 

--- a/examples/versatileab/.cargo/config.toml
+++ b/examples/versatileab/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "armv7r-none-eabihf"

--- a/examples/versatileab/Cargo.toml
+++ b/examples/versatileab/Cargo.toml
@@ -5,14 +5,13 @@ authors = [
 ]
 default-run = "hello"
 description = "Examples for the QEMU Versatile Application baseboard device (Arm Cortex-A8 or Arm Cortex-R5)"
-edition = "2021"
+edition = "2024"
 homepage = "https://github.com/rust-embedded/aarch32"
 license = "MIT OR Apache-2.0"
 name = "versatileab"
 publish = false
 readme = "README.md"
 repository = "https://github.com/rust-embedded/aarch32.git"
-rust-version = "1.83"
 version = "0.0.0"
 
 [dependencies]

--- a/examples/versatileab/README.md
+++ b/examples/versatileab/README.md
@@ -2,26 +2,93 @@
 
 This package contains example binaries for the Arm Versatile Application
 baseboard evaluation system, featuring an Arm Cortex-R5 processor or Arm
-Cortex-A8 processor core. This crate should be compiled for the
-`armv7r-none-eabihf`, `armv7r-none-eabi`, `armv7a-none-eabi` or
-`armv7a-none-eabihf` targets. The repo-level [`.cargo/config.toml`] will
-ensure the code runs on the appropriate QEMU configuration.
+Cortex-A8 processor core. This crate is tested on the following targets:
+
+- `armv4t-none-eabi` - ARMv4T, soft-float, Arm mode
+- `armv5te-none-eabi` - ARMv5TE, soft-float, Arm mode
+- `armv6-none-eabi` - ARMv6K, soft-float, Arm mode
+- `armv6-none-eabihf` - ARMv6K, hard-float, Arm mode
+- `armv7r-none-eabi` - ARMv7-R, soft-float, Arm mode
+- `armv7r-none-eabihf` - ARMv7-R, hard-float, Arm mode
+- `armv7a-none-eabi` - ARMv7-A, soft-float, Arm mode
+- `armv7a-none-eabihf` - ARMv7-R, hard-float, Arm mode
+- `thumbv6-none-eabi` - ARMv6K, soft-float, Thumb mode
+- `thumbv7r-none-eabi` - ARMv7-R, soft-float, Thumb mode
+- `thumbv7r-none-eabihf` - ARMv7-R, hard-float, Thumb mode
+- `thumbv7a-none-eabi` - ARMv7-A, soft-float, Thumb mode
+- `thumbv7a-none-eabihf` - ARMv7-A, hard-float, Thumb mode
+
+The repo-level [`.cargo/config.toml`] will ensure the code runs on the
+appropriate QEMU configuration. Note that there is no FPU support for ARMv4T or
+ARMv5TE or for ARMv6K when in Thumb mode.
+
+Several of our supported platforms have Tier 3 targets, which means Nightly Rust
+is required. This folder contains a [`rust-toolchain.toml`] which pins us to a
+specific release of nightly that is known to work.
 
 We have only tested this crate on `qemu-system-arm` emulating the Arm
 Versatile Application Board, not the real thing.
 
 [`.cargo/config.toml`]: ../../.cargo/config.toml
+[`rust-toolchain.toml`]: ./rust-toolchain.toml
+
+## Running
+
+Run these examples as follows:
+
+```console
+$ cargo run --bin hello
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.19s
+     Running `qemu-system-arm -machine versatileab -cpu cortex-r5f -semihosting -nographic -audio none -kernel target/armv7r-none-eabihf/debug/hello`
+Hello, this is semihosting! x = 1.000, y = 2.000
+PANIC: PanicInfo {
+    message: I am an example panic,
+    location: Location {
+        file: "src/bin/hello.rs",
+        line: 19,
+        column: 5,
+    },
+    can_unwind: true,
+    force_no_backtrace: false,
+}
+$ cargo run --bin hello --target armv4t-none-eabi -Zbuild-std=core
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.72s
+     Running `qemu-system-arm -machine versatileab -cpu arm926 -semihosting -nographic -audio none -kernel target/armv4t-none-eabi/debug/hello`
+Hello, this is semihosting! x = 1.000, y = 2.000
+PANIC: PanicInfo {
+    message: I am an example panic,
+    location: Location {
+        file: "src/bin/hello.rs",
+        line: 19,
+        column: 5,
+    },
+    can_unwind: true,
+    force_no_backtrace: false,
+}
+```
+
+## Debugging
+
+You can start a GDB server by adding `-- -s -S` to the end of the `cargo run`
+command, and the connect with GDB as follows:
+
+```console
+$ cargo run --bin hello -- -s -S
+# QEMU runs and hangs waiting for a connection. In another terminal run:
+$ arm-none-eabi-gdb -x commands.gdb target/armv7r-none-eabihf/debug/hello
+# GDB will start and connect to QEMU's GDB server. The commands.gdb file sets up some useful defaults.
+```
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.83.0 and up, as recorded
-by the `package.rust-version` property in `Cargo.toml`. These examples are
-not version controlled and we may change the MSRV at any time.
+These examples are guaranteed to compile on the version of Rust given in the
+[`rust-toolchain.toml`] file. These examples are not version controlled and we
+may change the MSRV at any time.
 
 ## Licence
 
-* Copyright (c) Ferrous Systems
-* Copyright (c) The Rust Embedded Devices Working Group developers
+- Copyright (c) Ferrous Systems
+- Copyright (c) The Rust Embedded Devices Working Group developers
 
 Licensed under either [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at
 your option.

--- a/examples/versatileab/commands.gdb
+++ b/examples/versatileab/commands.gdb
@@ -8,4 +8,6 @@ break _asm_irq_handler
 break _asm_fiq_handler
 layout asm
 layout regs
+set logging file ./target/debug.log
+set logging enabled on
 stepi

--- a/examples/versatileab/src/bin/abt-exception-a32.rs
+++ b/examples/versatileab/src/bin/abt-exception-a32.rs
@@ -10,7 +10,7 @@ use aarch32_rt::{entry, exception};
 use semihosting::println;
 use versatileab as _;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 static COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// The entry-point to the Rust application.
@@ -34,7 +34,7 @@ fn main() -> ! {
 }
 
 // These functions are written in assembly
-extern "C" {
+unsafe extern "C" {
     fn unaligned_from_a32();
 }
 

--- a/examples/versatileab/src/bin/abt-exception-t32.rs
+++ b/examples/versatileab/src/bin/abt-exception-t32.rs
@@ -10,7 +10,7 @@ use aarch32_rt::{entry, exception};
 use semihosting::println;
 use versatileab as _;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 static COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// The entry-point to the Rust application.
@@ -34,7 +34,7 @@ fn main() -> ! {
 }
 
 // These functions are written in assembly
-extern "C" {
+unsafe extern "C" {
     fn unaligned_from_t32();
 }
 

--- a/examples/versatileab/src/bin/prefetch-exception-a32.rs
+++ b/examples/versatileab/src/bin/prefetch-exception-a32.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
 }
 
 // These functions are written in assembly
-extern "C" {
+unsafe extern "C" {
     fn bkpt_from_a32();
 }
 

--- a/examples/versatileab/src/bin/prefetch-exception-t32.rs
+++ b/examples/versatileab/src/bin/prefetch-exception-t32.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
 }
 
 // These functions are written in assembly
-extern "C" {
+unsafe extern "C" {
     fn bkpt_from_t32();
 }
 

--- a/examples/versatileab/src/bin/svc-t32.rs
+++ b/examples/versatileab/src/bin/svc-t32.rs
@@ -16,9 +16,7 @@ fn main() -> ! {
     let y = x + 1;
     let z = (y as f64) * 1.5;
     println!("x = {}, y = {}, z = {:0.3}", x, y, z);
-    unsafe {
-        svc12_from_t32();
-    }
+    do_svc1();
     println!("x = {}, y = {}, z = {:0.3}", x, y, z);
     semihosting::process::exit(0);
 }
@@ -29,38 +27,16 @@ fn svc_handler(arg: u32) {
     println!("In svc_handler, with arg=0x{:06x}", arg);
     if arg == 0x12 {
         // test nested SVC calls
-        unsafe {
-            svc34_from_t32();
-        }
+        do_svc2();
     }
 }
 
-// These functions are written in assembly
-extern "C" {
-    fn svc12_from_t32();
-    fn svc34_from_t32();
+#[instruction_set(arm::t32)]
+fn do_svc1() {
+    aarch32_cpu::svc!(0x12);
 }
 
-core::arch::global_asm!(
-    r#"
-    // fn svc12_from_t32();
-    .thumb
-    .global svc12_from_t32
-    .type svc12_from_t32, %function
-    svc12_from_t32:
-        push    {{ r7, lr }}
-        svc     0x12
-        pop     {{ r7, pc }}
-    .size svc12_from_t32, . - svc12_from_t32
-
-    // fn svc34_from_t32();
-    .thumb
-    .global svc34_from_t32
-    .type svc34_from_t32, %function
-    svc34_from_t32:
-        push    {{ r7, lr }}
-        svc     0x34
-        pop     {{ r7, pc }}
-    .size svc34_from_t32, . - svc34_from_t32
-"#
-);
+#[instruction_set(arm::t32)]
+fn do_svc2() {
+    aarch32_cpu::svc!(0x34);
+}

--- a/examples/versatileab/src/bin/undef-exception-a32.rs
+++ b/examples/versatileab/src/bin/undef-exception-a32.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
 }
 
 // These functions are written in assembly
-extern "C" {
+unsafe extern "C" {
     fn udf_from_a32();
 }
 

--- a/examples/versatileab/src/bin/undef-exception-t32.rs
+++ b/examples/versatileab/src/bin/undef-exception-t32.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
 }
 
 // These functions are written in assembly
-extern "C" {
+unsafe extern "C" {
     fn udf_from_t32();
 }
 


### PR DESCRIPTION
* Lists all the targets supported by each example
* Notes that the examples are only tested on one specific version of nightly Rust due to using Tier 3 targets
* Turns on GDB logging
* Switches the examples to use Edition 2024
* Replaces some `global_asm!` functions with `instruction_set(arm::t32)` functions (so the T32 SVC examples now match the A32 SVC examples)
