### PR TITLE
Fix stack reporting

### DIFF
--- a/aarch32-cpu/src/asmv4.rs
+++ b/aarch32-cpu/src/asmv4.rs
@@ -17,7 +17,7 @@ pub fn irq_disable() {
             orr {0}, {flag}
             msr cpsr, {0}
         "#,
-        in(reg) 0,
+        inout(reg) 0 => _,
         flag = const {
             crate::register::Cpsr::new_with_raw_value(0)
                 .with_i(true)
@@ -42,7 +42,7 @@ pub unsafe fn irq_enable() {
             bic {0}, #{flag}
             msr cpsr, {0}
         "#,
-        in(reg) 0,
+        inout(reg) 0 => _,
         flag = const {
             crate::register::Cpsr::new_with_raw_value(0)
                 .with_i(true)

--- a/aarch32-cpu/src/stacks.rs
+++ b/aarch32-cpu/src/stacks.rs
@@ -54,7 +54,7 @@ unsafe fn stack_unused_bytes_asm(start: *const u32, size: usize) -> usize {
 3:
         "#,
         size = in(reg) size,
-        start = in(reg) start,
+        start = inout(reg) start => _,
         result = out(reg) result,
         scratch = out(reg) _,
     );

--- a/examples/mps3-an536/src/lib.rs
+++ b/examples/mps3-an536/src/lib.rs
@@ -143,7 +143,7 @@ fn stack_dump() {
     unsafe {
         for (name, range) in stacks {
             let (total, used) = stack_used_bytes(range.clone());
-            let percent = used * 100 / total;
+            let percent = (used * 100).checked_div(total).unwrap_or(999);
             // Send to stderr, so it doesn't mix with expected output on stdout
             semihosting::eprintln!(
                 "{} Stack = {:6} used of {:6} bytes ({:03}%) @ {:08x?}",

--- a/examples/versatileab/src/lib.rs
+++ b/examples/versatileab/src/lib.rs
@@ -10,6 +10,11 @@ compile_error!("This example/board is not compatible with the ARMv8-R architectu
 
 static WANT_PANIC: portable_atomic::AtomicBool = portable_atomic::AtomicBool::new(false);
 
+/// Track if we're already in the exit routine.
+///
+/// Stops us doing infinite recursion if we panic whilst doing the stack reporting.
+static IN_EXIT: portable_atomic::AtomicBool = portable_atomic::AtomicBool::new(false);
+
 /// Called when the application raises an unrecoverable `panic!`.
 ///
 /// Prints the panic to the console and then exits QEMU using a semihosting
@@ -32,7 +37,9 @@ pub fn want_panic() {
 
 /// Exit from QEMU with code
 pub fn exit(code: i32) -> ! {
-    stack_dump();
+    if !IN_EXIT.swap(true, portable_atomic::Ordering::Relaxed) {
+        stack_dump();
+    }
     semihosting::process::exit(code)
 }
 

--- a/examples/versatileab/src/lib.rs
+++ b/examples/versatileab/src/lib.rs
@@ -19,9 +19,9 @@ static WANT_PANIC: portable_atomic::AtomicBool = portable_atomic::AtomicBool::ne
 fn panic(info: &core::panic::PanicInfo) -> ! {
     semihosting::println!("PANIC: {:#?}", info);
     if WANT_PANIC.load(portable_atomic::Ordering::Relaxed) {
-        semihosting::process::exit(0);
+        exit(0);
     } else {
-        semihosting::process::abort();
+        exit(1);
     }
 }
 

--- a/examples/versatileab/src/lib.rs
+++ b/examples/versatileab/src/lib.rs
@@ -87,7 +87,7 @@ fn stack_dump() {
     unsafe {
         for (name, range) in stacks {
             let (total, used) = stack_used_bytes(range.clone());
-            let percent = used * 100 / total;
+            let percent = (used * 100).checked_div(total).unwrap_or(999);
             // Send to stderr, so it doesn't mix with expected output on stdout
             semihosting::eprintln!(
                 "{} Stack = {:6} used of {:6} bytes ({:03}%) @ {:08x?}",

--- a/justfile
+++ b/justfile
@@ -165,53 +165,53 @@ test-qemu: test-qemu-v4t test-qemu-v5te test-qemu-v6 test-qemu-v7a test-qemu-v7r
 test-qemu-v4t:
 	#!/bin/bash
 	FAIL=0
-	./tests.sh examples/versatileab armv4t-none-eabi -Zbuild-std=core {{verbose}} || FAIL=1
-	./tests.sh examples/versatileab thumbv4t-none-eabi -Zbuild-std=core {{verbose}} || FAIL=1
+	./tests.sh examples/versatileab armv4t-none-eabi -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab thumbv4t-none-eabi -Zbuild-std=core {{verbose}} --release || FAIL=1
 	if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 test-qemu-v5te:
 	#!/bin/bash
 	FAIL=0
-	./tests.sh examples/versatileab armv5te-none-eabi -Zbuild-std=core {{verbose}} || FAIL=1
-	./tests.sh examples/versatileab thumbv5te-none-eabi -Zbuild-std=core {{verbose}} || FAIL=1
+	./tests.sh examples/versatileab armv5te-none-eabi -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab thumbv5te-none-eabi -Zbuild-std=core {{verbose}} --release || FAIL=1
 	if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 test-qemu-v6:
 	#!/bin/bash
 	FAIL=0
-	./tests.sh examples/versatileab armv6-none-eabi -Zbuild-std=core {{verbose}} || FAIL=1
-	./tests.sh examples/versatileab armv6-none-eabihf -Zbuild-std=core {{verbose}} || FAIL=1
+	./tests.sh examples/versatileab armv6-none-eabi -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab armv6-none-eabihf -Zbuild-std=core {{verbose}} --release || FAIL=1
 	# Waiting on compiler-builtins to be updated
-	# ./tests.sh examples/versatileab thumbv6-none-eabi -Zbuild-std=core {{verbose}} || FAIL=1
+	# ./tests.sh examples/versatileab thumbv6-none-eabi -Zbuild-std=core {{verbose}} --release || FAIL=1
 	if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 test-qemu-v7a:
 	#!/bin/bash
 	FAIL=0
-	./tests.sh examples/versatileab armv7a-none-eabi {{verbose}} || FAIL=1
-	./tests.sh examples/versatileab thumbv7a-none-eabi -Zbuild-std=core {{verbose}} || FAIL=1
-	./tests.sh examples/versatileab armv7a-none-eabihf {{verbose}} || FAIL=1
-	./tests.sh examples/versatileab thumbv7a-none-eabihf -Zbuild-std=core {{verbose}} || FAIL=1
-	RUSTFLAGS=-Ctarget-feature=+d32 ./tests.sh examples/versatileab armv7a-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} || FAIL=1
-	RUSTFLAGS=-Ctarget-feature=+d32 ./tests.sh examples/versatileab thumbv7a-none-eabihf -Zbuild-std=core --features=fpu-d32 --target-dir=target-d32 {{verbose}} || FAIL=1
+	./tests.sh examples/versatileab armv7a-none-eabi {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab thumbv7a-none-eabi -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab armv7a-none-eabihf {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab thumbv7a-none-eabihf -Zbuild-std=core {{verbose}} --release || FAIL=1
+	RUSTFLAGS=-Ctarget-feature=+d32 ./tests.sh examples/versatileab armv7a-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
+	RUSTFLAGS=-Ctarget-feature=+d32 ./tests.sh examples/versatileab thumbv7a-none-eabihf -Zbuild-std=core --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
 	if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 test-qemu-v7r:
 	#!/bin/bash
 	FAIL=0
-	./tests.sh examples/versatileab armv7r-none-eabi {{verbose}} || FAIL=1
-	./tests.sh examples/versatileab thumbv7r-none-eabi -Zbuild-std=core {{verbose}} || FAIL=1
-	./tests.sh examples/versatileab armv7r-none-eabihf {{verbose}} || FAIL=1
-	./tests.sh examples/versatileab thumbv7r-none-eabihf -Zbuild-std=core {{verbose}} || FAIL=1
+	./tests.sh examples/versatileab armv7r-none-eabi {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab thumbv7r-none-eabi -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab armv7r-none-eabihf {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab thumbv7r-none-eabihf -Zbuild-std=core {{verbose}} --release || FAIL=1
 	if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 test-qemu-v8r:
 	#!/bin/bash
 	FAIL=0
-	./tests.sh examples/mps3-an536 armv8r-none-eabihf {{verbose}} || FAIL=1
-	./tests.sh examples/mps3-an536 thumbv8r-none-eabihf -Zbuild-std=core {{verbose}} || FAIL=1
-	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536 armv8r-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} || FAIL=1
-	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536 thumbv8r-none-eabihf -Zbuild-std=core --features=fpu-d32 --target-dir=target-d32 {{verbose}} || FAIL=1
+	./tests.sh examples/mps3-an536 armv8r-none-eabihf {{verbose}} --release || FAIL=1
+	./tests.sh examples/mps3-an536 thumbv8r-none-eabihf -Zbuild-std=core {{verbose}} --release || FAIL=1
+	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536 armv8r-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
+	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536 thumbv8r-none-eabihf -Zbuild-std=core --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
 	if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 # Run the special SMP test


### PR DESCRIPTION
The stack reporting code was exploding when compiled with `--release`. It is now fixed, but I'm not entirely sure why stopping the function being inlined fixes it. 