### PR TITLE
Fix links to license files.

### DIFF
--- a/aarch32-cpu/README.md
+++ b/aarch32-cpu/README.md
@@ -41,7 +41,7 @@ minor version release (e.g. from `0.3.0` to `0.3.1`, because this is still a
 * Copyright (c) Ferrous Systems
 * Copyright (c) The Rust Embedded Devices Working Group developers
 
-Licensed under either [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at
+Licensed under either [MIT](../LICENSE-MIT) or [Apache-2.0](../LICENSE-APACHE) at
 your option.
 
 ## Contribution

--- a/aarch32-rt-macros/README.md
+++ b/aarch32-rt-macros/README.md
@@ -18,7 +18,7 @@ minor version release (e.g. from `0.3.0` to `0.3.1`, because this is still a
 * Copyright (c) Ferrous Systems
 * Copyright (c) The Rust Embedded Devices Working Group developers
 
-Licensed under either [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at
+Licensed under either [MIT](../LICENSE-MIT) or [Apache-2.0](../LICENSE-APACHE) at
 your option.
 
 ## Contribution

--- a/aarch32-rt/README.md
+++ b/aarch32-rt/README.md
@@ -34,7 +34,7 @@ minor version release (e.g. from `0.3.0` to `0.3.1`, because this is still a
 * Copyright (c) Ferrous Systems
 * Copyright (c) The Rust Embedded Devices Working Group developers
 
-Licensed under either [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at
+Licensed under either [MIT](../LICENSE-MIT) or [Apache-2.0](../LICENSE-APACHE) at
 your option.
 
 ## Contribution

--- a/arm-targets/README.md
+++ b/arm-targets/README.md
@@ -41,7 +41,7 @@ minor version release (e.g. from `0.3.0` to `0.3.1`, because this is still a
 * Copyright (c) Ferrous Systems
 * Copyright (c) The Rust Embedded Devices Working Group developers
 
-Licensed under either [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at
+Licensed under either [MIT](../LICENSE-MIT) or [Apache-2.0](../LICENSE-APACHE) at
 your option.
 
 ## Contribution

--- a/examples/mps3-an536/README.md
+++ b/examples/mps3-an536/README.md
@@ -80,7 +80,7 @@ may change the MSRV at any time.
 - Copyright (c) Ferrous Systems
 - Copyright (c) The Rust Embedded Devices Working Group developers
 
-Licensed under either [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at
+Licensed under either [MIT](../LICENSE-MIT) or [Apache-2.0](../LICENSE-APACHE) at
 your option.
 
 ## Contribution

--- a/examples/versatileab/README.md
+++ b/examples/versatileab/README.md
@@ -90,7 +90,7 @@ may change the MSRV at any time.
 - Copyright (c) Ferrous Systems
 - Copyright (c) The Rust Embedded Devices Working Group developers
 
-Licensed under either [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at
+Licensed under either [MIT](../LICENSE-MIT) or [Apache-2.0](../LICENSE-APACHE) at
 your option.
 
 ## Contribution


### PR DESCRIPTION
The links to the licenses in the README files were wrong. This fixes the links.