### PR TITLE
Update PMSA types

### DIFF
--- a/aarch32-cpu/src/pmsav8.rs
+++ b/aarch32-cpu/src/pmsav8.rs
@@ -53,8 +53,8 @@ impl El1Mpu {
         register::Prselr::write(register::Prselr(idx as u32));
         let prbar = register::Prbar::read();
         let prlar = register::Prlar::read();
-        let start_addr = (prbar.base().value() << 6) as *mut u8;
-        let end_addr = ((prlar.limit().value() << 6) | 0x3F) as *mut u8;
+        let start_addr = prbar.base_address();
+        let end_addr = prlar.limit_address();
         Some(El1Region {
             range: start_addr..=end_addr,
             shareability: prbar.shareability(),

--- a/aarch32-cpu/src/register/armv8r/prbar.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR (*Protection Region Base Address Register*)
 
-use arbitrary_int::u26;
+use arbitrary_int::{traits::Integer, u26};
 
 use crate::register::{SysReg, SysRegRead, SysRegWrite};
 
@@ -80,5 +80,10 @@ impl Prbar {
         unsafe {
             <Self as SysRegWrite>::write_raw(value.raw_value());
         }
+    }
+
+    /// Get the base address
+    pub fn base_address(self) -> *mut u8 {
+        (self.base().as_usize() << 6) as *mut u8
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar0.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar0.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR0 (*Protection Region Base Address Register 0*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR0 (*Protection Region Base Address Register 0*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar0 {}
 impl Prbar0 {
     #[inline]
     /// Reads PRBAR0 (*Protection Region Base Address Register 0*)
-    pub fn read() -> Prbar0 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar0 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar1.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar1.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR1 (*Protection Region Base Address Register 1*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR1 (*Protection Region Base Address Register 1*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar1 {}
 impl Prbar1 {
     #[inline]
     /// Reads PRBAR1 (*Protection Region Base Address Register 1*)
-    pub fn read() -> Prbar1 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar1 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar10.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar10.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR10 (*Protection Region Base Address Register 10*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR10 (*Protection Region Base Address Register 10*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar10 {}
 impl Prbar10 {
     #[inline]
     /// Reads PRBAR10 (*Protection Region Base Address Register 10*)
-    pub fn read() -> Prbar10 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar10 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar11.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar11.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR11 (*Protection Region Base Address Register 11*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR11 (*Protection Region Base Address Register 11*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar11 {}
 impl Prbar11 {
     #[inline]
     /// Reads PRBAR11 (*Protection Region Base Address Register 11*)
-    pub fn read() -> Prbar11 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar11 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar12.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar12.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR12 (*Protection Region Base Address Register 12*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR12 (*Protection Region Base Address Register 12*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar12 {}
 impl Prbar12 {
     #[inline]
     /// Reads PRBAR12 (*Protection Region Base Address Register 12*)
-    pub fn read() -> Prbar12 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar12 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar13.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar13.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR13 (*Protection Region Base Address Register 13*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR13 (*Protection Region Base Address Register 13*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar13 {}
 impl Prbar13 {
     #[inline]
     /// Reads PRBAR13 (*Protection Region Base Address Register 13*)
-    pub fn read() -> Prbar13 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar13 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar14.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar14.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR14 (*Protection Region Base Address Register 14*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR14 (*Protection Region Base Address Register 14*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar14 {}
 impl Prbar14 {
     #[inline]
     /// Reads PRBAR14 (*Protection Region Base Address Register 14*)
-    pub fn read() -> Prbar14 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar14 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar15.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar15.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR15 (*Protection Region Base Address Register 15*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR15 (*Protection Region Base Address Register 15*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar15 {}
 impl Prbar15 {
     #[inline]
     /// Reads PRBAR15 (*Protection Region Base Address Register 15*)
-    pub fn read() -> Prbar15 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar15 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar2.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar2.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR2 (*Protection Region Base Address Register 2*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR2 (*Protection Region Base Address Register 2*)
 #[derive(Debug, Clone, Copy)]
@@ -20,9 +20,9 @@ impl crate::register::SysRegRead for Prbar2 {}
 
 impl Prbar2 {
     #[inline]
-    /// Reads PRBAR2 (*Protection Region Base Address Register 2*)
-    pub fn read() -> Prbar2 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    /// Reads PRBAR0 (*Protection Region Base Address Register 2*)
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar2 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar3.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar3.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR3 (*Protection Region Base Address Register 3*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR3 (*Protection Region Base Address Register 3*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar3 {}
 impl Prbar3 {
     #[inline]
     /// Reads PRBAR3 (*Protection Region Base Address Register 3*)
-    pub fn read() -> Prbar3 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar3 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar4.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar4.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR4 (*Protection Region Base Address Register 4*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR4 (*Protection Region Base Address Register 4*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar4 {}
 impl Prbar4 {
     #[inline]
     /// Reads PRBAR4 (*Protection Region Base Address Register 4*)
-    pub fn read() -> Prbar4 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar4 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar5.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar5.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR5 (*Protection Region Base Address Register 5*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR5 (*Protection Region Base Address Register 5*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar5 {}
 impl Prbar5 {
     #[inline]
     /// Reads PRBAR5 (*Protection Region Base Address Register 5*)
-    pub fn read() -> Prbar5 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar5 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar6.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar6.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR6 (*Protection Region Base Address Register 6*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR6 (*Protection Region Base Address Register 6*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar6 {}
 impl Prbar6 {
     #[inline]
     /// Reads PRBAR6 (*Protection Region Base Address Register 6*)
-    pub fn read() -> Prbar6 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar6 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar7.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar7.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR7 (*Protection Region Base Address Register 7*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR7 (*Protection Region Base Address Register 7*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar7 {}
 impl Prbar7 {
     #[inline]
     /// Reads PRBAR7 (*Protection Region Base Address Register 7*)
-    pub fn read() -> Prbar7 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar7 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar8.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar8.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR8 (*Protection Region Base Address Register 8*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR8 (*Protection Region Base Address Register 8*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar8 {}
 impl Prbar8 {
     #[inline]
     /// Reads PRBAR8 (*Protection Region Base Address Register 8*)
-    pub fn read() -> Prbar8 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar8 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prbar9.rs
+++ b/aarch32-cpu/src/register/armv8r/prbar9.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRBAR9 (*Protection Region Base Address Register 9*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prbar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRBAR9 (*Protection Region Base Address Register 9*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prbar9 {}
 impl Prbar9 {
     #[inline]
     /// Reads PRBAR9 (*Protection Region Base Address Register 9*)
-    pub fn read() -> Prbar9 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prbar {
+        unsafe { Prbar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prbar9 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prbar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR (*Protection Region Limit Address Register*)
 
-use arbitrary_int::{u26, u3};
+use arbitrary_int::{traits::Integer, u26, u3};
 
 use crate::register::{SysReg, SysRegRead, SysRegWrite};
 
@@ -45,5 +45,10 @@ impl Prlar {
         unsafe {
             <Self as SysRegWrite>::write_raw(value.raw_value());
         }
+    }
+
+    /// Gets the limit address
+    pub fn limit_address(self) -> *mut u8 {
+        ((self.limit().as_usize() << 6) | 0b111_111) as *mut u8
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar0.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar0.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR0 (*Protection Region Limit Address Register 0*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR0 (*Protection Region Limit Address Register 0*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar0 {}
 impl Prlar0 {
     #[inline]
     /// Reads PRLAR0 (*Protection Region Limit Address Register 0*)
-    pub fn read() -> Prlar0 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar0 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar1.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar1.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR1 (*Protection Region Limit Address Register 1*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR1 (*Protection Region Limit Address Register 1*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar1 {}
 impl Prlar1 {
     #[inline]
     /// Reads PRLAR1 (*Protection Region Limit Address Register 1*)
-    pub fn read() -> Prlar1 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar1 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar10.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar10.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR10 (*Protection Region Limit Address Register 10*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR10 (*Protection Region Limit Address Register 10*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar10 {}
 impl Prlar10 {
     #[inline]
     /// Reads PRLAR10 (*Protection Region Limit Address Register 10*)
-    pub fn read() -> Prlar10 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar10 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar11.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar11.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR11 (*Protection Region Limit Address Register 11*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR11 (*Protection Region Limit Address Register 11*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar11 {}
 impl Prlar11 {
     #[inline]
     /// Reads PRLAR11 (*Protection Region Limit Address Register 11*)
-    pub fn read() -> Prlar11 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar11 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar12.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar12.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR12 (*Protection Region Limit Address Register 12*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR12 (*Protection Region Limit Address Register 12*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar12 {}
 impl Prlar12 {
     #[inline]
     /// Reads PRLAR12 (*Protection Region Limit Address Register 12*)
-    pub fn read() -> Prlar12 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar12 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar13.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar13.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR13 (*Protection Region Limit Address Register 13*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR13 (*Protection Region Limit Address Register 13*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar13 {}
 impl Prlar13 {
     #[inline]
     /// Reads PRLAR13 (*Protection Region Limit Address Register 13*)
-    pub fn read() -> Prlar13 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar13 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar14.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar14.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR14 (*Protection Region Limit Address Register 14*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR14 (*Protection Region Limit Address Register 14*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar14 {}
 impl Prlar14 {
     #[inline]
     /// Reads PRLAR14 (*Protection Region Limit Address Register 14*)
-    pub fn read() -> Prlar14 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar14 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar15.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar15.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR15 (*Protection Region Limit Address Register 15*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR15 (*Protection Region Limit Address Register 15*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar15 {}
 impl Prlar15 {
     #[inline]
     /// Reads PRLAR15 (*Protection Region Limit Address Register 15*)
-    pub fn read() -> Prlar15 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar15 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar2.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar2.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR2 (*Protection Region Limit Address Register 2*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR2 (*Protection Region Limit Address Register 2*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar2 {}
 impl Prlar2 {
     #[inline]
     /// Reads PRLAR2 (*Protection Region Limit Address Register 2*)
-    pub fn read() -> Prlar2 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar2 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar3.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar3.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR3 (*Protection Region Limit Address Register 3*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR3 (*Protection Region Limit Address Register 3*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar3 {}
 impl Prlar3 {
     #[inline]
     /// Reads PRLAR3 (*Protection Region Limit Address Register 3*)
-    pub fn read() -> Prlar3 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar3 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar4.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar4.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR4 (*Protection Region Limit Address Register 4*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR4 (*Protection Region Limit Address Register 4*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar4 {}
 impl Prlar4 {
     #[inline]
     /// Reads PRLAR4 (*Protection Region Limit Address Register 4*)
-    pub fn read() -> Prlar4 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar4 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar5.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar5.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR5 (*Protection Region Limit Address Register 5*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR5 (*Protection Region Limit Address Register 5*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar5 {}
 impl Prlar5 {
     #[inline]
     /// Reads PRLAR5 (*Protection Region Limit Address Register 5*)
-    pub fn read() -> Prlar5 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar5 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar6.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar6.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR6 (*Protection Region Limit Address Register 6*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR6 (*Protection Region Limit Address Register 6*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar6 {}
 impl Prlar6 {
     #[inline]
     /// Reads PRLAR6 (*Protection Region Limit Address Register 6*)
-    pub fn read() -> Prlar6 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar6 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar7.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar7.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR7 (*Protection Region Limit Address Register 7*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR7 (*Protection Region Limit Address Register 7*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar7 {}
 impl Prlar7 {
     #[inline]
     /// Reads PRLAR7 (*Protection Region Limit Address Register 7*)
-    pub fn read() -> Prlar7 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar7 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar8.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar8.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR8 (*Protection Region Limit Address Register 8*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR8 (*Protection Region Limit Address Register 8*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar8 {}
 impl Prlar8 {
     #[inline]
     /// Reads PRLAR8 (*Protection Region Limit Address Register 8*)
-    pub fn read() -> Prlar8 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar8 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/armv8r/prlar9.rs
+++ b/aarch32-cpu/src/register/armv8r/prlar9.rs
@@ -1,6 +1,6 @@
 //! Code for managing PRLAR9 (*Protection Region Limit Address Register 9*)
 
-use crate::register::{SysReg, SysRegRead, SysRegWrite};
+use crate::register::{Prlar, SysReg, SysRegRead, SysRegWrite};
 
 /// PRLAR9 (*Protection Region Limit Address Register 9*)
 #[derive(Debug, Clone, Copy)]
@@ -21,8 +21,8 @@ impl crate::register::SysRegRead for Prlar9 {}
 impl Prlar9 {
     #[inline]
     /// Reads PRLAR9 (*Protection Region Limit Address Register 9*)
-    pub fn read() -> Prlar9 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Prlar {
+        unsafe { Prlar::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +35,9 @@ impl Prlar9 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Prlar) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/examples/mps3-an536/reference/registers-armv8r-none-eabihf.out
+++ b/examples/mps3-an536/reference/registers-armv8r-none-eabihf.out
@@ -19,21 +19,53 @@ Region 12: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: Re
 Region 13: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
 Region 14: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
 Region 15: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 0: El1Region { range: 0x0..=0x3fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
-Region 1: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 2: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 3: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 4: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 5: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 6: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 7: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 8: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 9: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 10: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 11: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 12: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 13: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 14: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 15: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
+Region 0: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 1: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 2: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 3: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 4: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 5: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 6: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 7: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 8: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 9: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 10: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 11: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 12: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 13: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 14: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 15: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 0: El1Region { range: 0x0..=0xfffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 1: El1Region { range: 0x10000000..=0x1fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 2: El1Region { range: 0x20000000..=0x2fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 3: El1Region { range: 0x30000000..=0x3fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 4: El1Region { range: 0x40000000..=0x4fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 5: El1Region { range: 0x50000000..=0x5fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 6: El1Region { range: 0x60000000..=0x6fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 7: El1Region { range: 0x70000000..=0x7fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 8: El1Region { range: 0x80000000..=0x8fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 9: El1Region { range: 0x90000000..=0x9fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 10: El1Region { range: 0xa0000000..=0xafffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 11: El1Region { range: 0xb0000000..=0xbfffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 12: El1Region { range: 0xc0000000..=0xcfffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 13: El1Region { range: 0xd0000000..=0xdfffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 14: El1Region { range: 0xe0000000..=0xefffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 15: El1Region { range: 0xf0000000..=0xffffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 0: Prbar { base: 00000000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 1: Prbar { base: 00400000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 2: Prbar { base: 00800000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 3: Prbar { base: 00c00000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 4: Prbar { base: 01000000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 5: Prbar { base: 01400000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 6: Prbar { base: 01800000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 7: Prbar { base: 01c00000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 8: Prbar { base: 02000000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 9: Prbar { base: 02400000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 10: Prbar { base: 02800000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 11: Prbar { base: 02c00000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 12: Prbar { base: 03000000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 13: Prbar { base: 03400000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 14: Prbar { base: 03800000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 15: Prbar { base: 03c00000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
 SCTLR { IE=0 TE=0 NMFI=0 EE=0 U=1 FI=0 DZ=1 BR=1 RR=0 V=0 I=0 Z=1 SW=0 C=0 A=0 M=0 } before setting C, I and Z
 SCTLR { IE=0 TE=0 NMFI=0 EE=0 U=1 FI=0 DZ=1 BR=1 RR=0 V=0 I=1 Z=1 SW=0 C=1 A=0 M=0 } after

--- a/examples/mps3-an536/reference/registers-thumbv8r-none-eabihf.out
+++ b/examples/mps3-an536/reference/registers-thumbv8r-none-eabihf.out
@@ -19,21 +19,53 @@ Region 12: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: Re
 Region 13: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
 Region 14: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
 Region 15: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 0: El1Region { range: 0x0..=0x3fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
-Region 1: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 2: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 3: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 4: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 5: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 6: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 7: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 8: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 9: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 10: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 11: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 12: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 13: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 14: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
-Region 15: El1Region { range: 0x0..=0x3f, shareability: NonShareable, access: ReadWriteNoEL0, no_exec: false, mair: 0, enable: false }
+Region 0: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 1: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 2: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 3: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 4: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 5: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 6: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 7: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 8: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 9: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 10: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 11: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 12: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 13: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 14: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 15: Prbar { base: 00000000, shareability: NonShareable, access_perms: ReadWriteNoEL0, nx: false    }
+Region 0: El1Region { range: 0x0..=0xfffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 1: El1Region { range: 0x10000000..=0x1fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 2: El1Region { range: 0x20000000..=0x2fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 3: El1Region { range: 0x30000000..=0x3fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 4: El1Region { range: 0x40000000..=0x4fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 5: El1Region { range: 0x50000000..=0x5fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 6: El1Region { range: 0x60000000..=0x6fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 7: El1Region { range: 0x70000000..=0x7fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 8: El1Region { range: 0x80000000..=0x8fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 9: El1Region { range: 0x90000000..=0x9fffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 10: El1Region { range: 0xa0000000..=0xafffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 11: El1Region { range: 0xb0000000..=0xbfffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 12: El1Region { range: 0xc0000000..=0xcfffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 13: El1Region { range: 0xd0000000..=0xdfffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 14: El1Region { range: 0xe0000000..=0xefffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 15: El1Region { range: 0xf0000000..=0xffffffff, shareability: OuterShareable, access: ReadWrite, no_exec: true, mair: 0, enable: true }
+Region 0: Prbar { base: 00000000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 1: Prbar { base: 00400000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 2: Prbar { base: 00800000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 3: Prbar { base: 00c00000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 4: Prbar { base: 01000000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 5: Prbar { base: 01400000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 6: Prbar { base: 01800000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 7: Prbar { base: 01c00000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 8: Prbar { base: 02000000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 9: Prbar { base: 02400000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 10: Prbar { base: 02800000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 11: Prbar { base: 02c00000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 12: Prbar { base: 03000000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 13: Prbar { base: 03400000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 14: Prbar { base: 03800000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
+Region 15: Prbar { base: 03c00000, shareability: OuterShareable, access_perms: ReadWrite, nx: true     }
 SCTLR { IE=0 TE=0 NMFI=0 EE=0 U=1 FI=0 DZ=1 BR=1 RR=0 V=0 I=0 Z=1 SW=0 C=0 A=0 M=0 } before setting C, I and Z
 SCTLR { IE=0 TE=0 NMFI=0 EE=0 U=1 FI=0 DZ=1 BR=1 RR=0 V=0 I=1 Z=1 SW=0 C=1 A=0 M=0 } after

--- a/examples/mps3-an536/src/bin/registers.rs
+++ b/examples/mps3-an536/src/bin/registers.rs
@@ -93,7 +93,7 @@ fn mpu_pmsa_v8() {
             Cacheable, El1AccessPerms, El1Config, El1Mpu, El1Region, El1Shareability, MemAttr,
             RwAllocPolicy,
         },
-        register::Mpuir,
+        register::{Mpuir, armv8r::*},
     };
 
     // How many regions?
@@ -109,19 +109,157 @@ fn mpu_pmsa_v8() {
             println!("Region {}: {:?}", idx, region);
         }
     }
+    println!("Region 0: {:08x?}", Prbar0::read());
+    println!("Region 1: {:08x?}", Prbar1::read());
+    println!("Region 2: {:08x?}", Prbar2::read());
+    println!("Region 3: {:08x?}", Prbar3::read());
+    println!("Region 4: {:08x?}", Prbar4::read());
+    println!("Region 5: {:08x?}", Prbar5::read());
+    println!("Region 6: {:08x?}", Prbar6::read());
+    println!("Region 7: {:08x?}", Prbar7::read());
+    println!("Region 8: {:08x?}", Prbar8::read());
+    println!("Region 9: {:08x?}", Prbar9::read());
+    println!("Region 10: {:08x?}", Prbar10::read());
+    println!("Region 11: {:08x?}", Prbar11::read());
+    println!("Region 12: {:08x?}", Prbar12::read());
+    println!("Region 13: {:08x?}", Prbar13::read());
+    println!("Region 14: {:08x?}", Prbar14::read());
+    println!("Region 15: {:08x?}", Prbar15::read());
 
     // Load a config (but don't enable it)
     #[allow(clippy::zero_ptr)]
     mpu.configure(&El1Config {
         background_config: true,
-        regions: &[El1Region {
-            range: 0x0000_0000 as *mut u8..=0x3FFF_FFFF as *mut u8,
-            shareability: El1Shareability::OuterShareable,
-            access: El1AccessPerms::ReadWrite,
-            no_exec: true,
-            mair: 0,
-            enable: true,
-        }],
+        regions: &[
+            El1Region {
+                range: 0x0000_0000 as *mut u8..=0x0FFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0x1000_0000 as *mut u8..=0x1FFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0x2000_0000 as *mut u8..=0x2FFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0x3000_0000 as *mut u8..=0x3FFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0x4000_0000 as *mut u8..=0x4FFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0x5000_0000 as *mut u8..=0x5FFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0x6000_0000 as *mut u8..=0x6FFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0x7000_0000 as *mut u8..=0x7FFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0x8000_0000 as *mut u8..=0x8FFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0x9000_0000 as *mut u8..=0x9FFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0xA000_0000 as *mut u8..=0xAFFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0xB000_0000 as *mut u8..=0xBFFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0xC000_0000 as *mut u8..=0xCFFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0xD000_0000 as *mut u8..=0xDFFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0xE000_0000 as *mut u8..=0xEFFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+            El1Region {
+                range: 0xF000_0000 as *mut u8..=0xFFFF_FFFF as *mut u8,
+                shareability: El1Shareability::OuterShareable,
+                access: El1AccessPerms::ReadWrite,
+                no_exec: true,
+                mair: 0,
+                enable: true,
+            },
+        ],
         memory_attributes: &[MemAttr::NormalMemory {
             outer: Cacheable::WriteThroughNonTransient(RwAllocPolicy::RW),
             inner: Cacheable::WriteThroughNonTransient(RwAllocPolicy::RW),
@@ -135,6 +273,22 @@ fn mpu_pmsa_v8() {
             println!("Region {}: {:?}", idx, region);
         }
     }
+    println!("Region 0: {:08x?}", Prbar0::read());
+    println!("Region 1: {:08x?}", Prbar1::read());
+    println!("Region 2: {:08x?}", Prbar2::read());
+    println!("Region 3: {:08x?}", Prbar3::read());
+    println!("Region 4: {:08x?}", Prbar4::read());
+    println!("Region 5: {:08x?}", Prbar5::read());
+    println!("Region 6: {:08x?}", Prbar6::read());
+    println!("Region 7: {:08x?}", Prbar7::read());
+    println!("Region 8: {:08x?}", Prbar8::read());
+    println!("Region 9: {:08x?}", Prbar9::read());
+    println!("Region 10: {:08x?}", Prbar10::read());
+    println!("Region 11: {:08x?}", Prbar11::read());
+    println!("Region 12: {:08x?}", Prbar12::read());
+    println!("Region 13: {:08x?}", Prbar13::read());
+    println!("Region 14: {:08x?}", Prbar14::read());
+    println!("Region 15: {:08x?}", Prbar15::read());
 }
 
 fn test_changing_sctlr() {


### PR DESCRIPTION
* Make the direct-access PMSA registers easier to use, by having them each return a `Prbar` or `Prlar` bitfield value.
* Update the tests to check we are reading/writing the right MPU registers.
