### PR TITLE
Set up rust-analyzer linked projects for VSCode.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,9 @@
     "rust-analyzer.check.allTargets": false,
     "rust-analyzer.check.extraArgs": ["--bins"],
     "rust-analyzer.checkOnSave": true,
+    "rust-analyzer.linkedProjects": [
+        "./Cargo.toml",
+        "examples/versatileab/Cargo.toml",
+        "examples/mps3-an536/Cargo.toml"
+    ]
 }


### PR DESCRIPTION
The repo contains three separate workspaces, and rust-analyzer doesn't automatically detect the other two. So, let's tell it about them.

Now auto-complete etc works in the example projects.