### PR TITLE
Implement per-architecture IFSR and DFSR types.

### DIFF
--- a/aarch32-cpu/src/register/dfsr.rs
+++ b/aarch32-cpu/src/register/dfsr.rs
@@ -1,52 +1,252 @@
 //! Code for managing DFSR (*Data Fault Status Register*)
 
-use arbitrary_int::{prelude::*, u4, u5};
+#[cfg(arm_architecture = "v6")]
+use arbitrary_int::u4;
 
 use crate::register::{SysReg, SysRegRead, SysRegWrite};
 
-use super::ifsr::FsrStatus;
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+/// DFSR (*Data Fault Status Register*)
+#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[repr(u8)]
-pub enum DfsrStatus {
-    AlignmentFault = 0b00001,
-    FaultOnInstructionCacheMaintenance = 0b00100,
-    AsyncExternalAbort = 0b10110,
-    AsyncParityErrorOnMemAccess = 0b11000,
-    CommonFsr(FsrStatus),
-}
-
-impl TryFrom<u8> for DfsrStatus {
-    type Error = u8;
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0b00001 => Ok(DfsrStatus::AlignmentFault),
-            0b00100 => Ok(DfsrStatus::FaultOnInstructionCacheMaintenance),
-            0b10110 => Ok(DfsrStatus::AsyncExternalAbort),
-            0b11000 => Ok(DfsrStatus::AsyncParityErrorOnMemAccess),
-            _ => FsrStatus::try_from(value)
-                .map(DfsrStatus::CommonFsr)
-                .map_err(|_| value),
-        }
-    }
+#[cfg(arm_architecture = "v5te")]
+pub struct Dfsr {
+    /// Status
+    #[bits([0..=3], rw)]
+    status: Option<DfsrStatus>,
 }
 
 /// DFSR (*Data Fault Status Register*)
-#[bitbybit::bitfield(u32, defmt_bitfields(feature = "defmt"))]
+#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v6")]
 pub struct Dfsr {
-    /// External abort qualifier
-    #[bit(12, rw)]
-    ext: bool,
-    /// Write Not Read bit.
+    /// Write not Read
     #[bit(11, rw)]
     wnr: bool,
+    /// Domain
     #[bits(4..=7, rw)]
     domain: u4,
     /// Status bitfield.
     #[bits([0..=3, 10], rw)]
-    status_raw: u5,
+    status: Option<DfsrStatus>,
+}
+
+/// DFSR (*Data Fault Status Register*)
+#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v7-r")]
+pub struct Dfsr {
+    /// Status bitfield.
+    #[bits([0..=3, 10], rw)]
+    status: Option<DfsrStatus>,
+}
+
+/// DFSR (*Instruction Fault Status Register*)
+#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v7-a")]
+pub struct Dfsr {
+    /// FAR not Valid
+    #[bit(16, rw)]
+    fnv: bool,
+    /// Cache manintenance fault
+    #[bit(13, rw)]
+    cm: bool,
+    /// External Abort type
+    #[bit(12, rw)]
+    ext: bool,
+    /// Write not Read
+    #[bit(11, rw)]
+    wnr: bool,
+    /// Status bitfield.
+    #[bits([0..=5], rw)]
+    status: Option<DfsrStatus>,
+}
+
+/// DFSR (*Data Fault Status Register*)
+#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
+#[cfg(arm_architecture = "v8-r")]
+pub struct Dfsr {
+    /// FAR not Valid
+    #[bit(16, rw)]
+    fnv: bool,
+    /// Cache manintenance fault
+    #[bit(13, rw)]
+    cm: bool,
+    /// External Abort type
+    #[bit(12, rw)]
+    ext: bool,
+    /// Write not Read
+    #[bit(11, rw)]
+    wnr: bool,
+    /// Status bitfield.
+    #[bits([0..=5], rw)]
+    status: Option<DfsrStatus>,
+}
+
+/// Fault status register enumeration for DFSR
+#[bitbybit::bitenum(u4, exhaustive = false)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v5te")]
+#[derive(Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DfsrStatus {
+    AlignmentFault = 1,
+    Debug = 2,
+    AlignmentAlt = 3,
+    TranslationFaultFirstLevel = 5,
+    TranslationFaultSecondLevel = 7,
+    SyncExtAbort = 8,
+    DomainFaultFirstLevel = 9,
+    SyncExtAbortAlt = 10,
+    DomainFaultSecondLevel = 11,
+    SyncExtAbortOnTranslationTableWalkFirstLevel = 12,
+    PermissionFaultFirstLevel = 13,
+    SyncExtAbortOnTranslationTableWalkSecondLevel = 14,
+    PermissionFaultSecondLevel = 15,
+}
+
+/// Fault status register enumeration for DFSR
+#[bitbybit::bitenum(u5, exhaustive = false)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v6")]
+#[derive(Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DfsrStatus {
+    /// Alignment fault
+    AlignmentFault = 0b00001,
+    /// Debug event fault
+    Debug = 0b00010,
+    /// Access Flag fault on Section
+    AccessFlagFaultFirstLevel = 0b00011,
+    /// Cache maintenance operation fault[2]
+    CacheMaintenance = 0b00100,
+    /// Translation fault on Section
+    TranslationFaultFirstLevel = 0b00101,
+    /// Access Flag fault on Page
+    AccessFlagFaultSecondLevel = 0b00110,
+    /// Translation fault on Page
+    TranslationFaultSecondLevel = 0b00111,
+    /// Precise External Abort
+    PreciseExternalAbort = 0b01000,
+    /// Domain fault on Section
+    DomainFaultFirstLevel = 0b01001,
+    /// Domain fault on Page
+    DomainFaultSecondLevel = 0b01011,
+    /// External abort on translation, first level
+    SyncExtAbortOnTranslationTableWalkFirstLevel = 0b01100,
+    /// Permission fault on Section
+    PermissionFaultFirstLevel = 0b01101,
+    /// External abort on translation, second level
+    SyncExtAbortOnTranslationTableWalkSecondLevel = 0b01110,
+    /// Permission fault on Page
+    PermissionFaultSecondLevel = 0b01111,
+    /// Imprecise External Abort
+    ImpreciseExtAbort = 0b10110,
+}
+
+/// Fault status register enumeration for DFSR
+#[bitbybit::bitenum(u5, exhaustive = false)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v7-r")]
+#[derive(Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DfsrStatus {
+    /// Alignment fault
+    AlignmentFault = 1,
+    /// Debug exception
+    Debug = 2,
+    /// Translation fault
+    Translation = 4,
+    /// Permission fault
+    Permission = 12,
+    /// Synchronous external abort, other than synchronous parity or ECC error
+    SError = 16,
+    /// SError interrupt
+    SErrorInterrupt = 17,
+    /// Synchronous parity or ECC error on memory access
+    SyncParErrorOnMemAccess = 24,
+    /// SError parity or ECC error on memory access
+    SErrorParityEccError = 25,
+}
+
+/// Fault status register enumeration for DFSR
+#[bitbybit::bitenum(u6, exhaustive = false)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v7-a")]
+#[derive(Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DfsrStatus {
+    /// Alignment fault.
+    AlignmentFault = 0b00001,
+    /// Debug exception.
+    Debug = 0b00010,
+    /// Access flag fault, level 1.
+    AccessFlagFaultFirstLevel = 0b00011,
+    /// Fault on instruction cache maintenance.
+    CacheMaintenance = 0b00100,
+    /// Translation fault, level 1.
+    TranslationFaultFirstLevel = 0b00101,
+    /// Access flag fault, level 2.
+    AccessFlagFaultSecondLevel = 0b00110,
+    /// Translation fault, level 2.
+    TranslationFaultSecondLevel = 0b00111,
+    /// Synchronous External abort, not on translation table walk.
+    SyncExtAbort = 0b01000,
+    /// Domain fault, level 1.
+    DomainFaultFirstLevel = 0b01001,
+    /// Domain fault, level 2.
+    DomainFaultSecondLevel = 0b01011,
+    /// Synchronous External abort, on translation table walk, level 1.
+    SyncExtAbortOnTranslationTableWalkFirstLevel = 0b01100,
+    /// Permission fault, level 1.
+    PermissionFaultFirstLevel = 0b01101,
+    /// Synchronous External abort, on translation table walk, level 2.
+    SyncExtAbortOnTranslationTableWalkSecondLevel = 0b01110,
+    /// Permission fault, level 2.
+    PermissionFaultSecondLevel = 0b01111,
+    /// TLB conflict abort.
+    TldConflictAbort = 0b10000,
+    /// SError exception.
+    SError = 0b10110,
+    /// SError exception, from a parity or ECC error on memory access.
+    SErrorParityEccError = 0b11000,
+    /// Synchronous parity or ECC error on memory access, not on translation table walk.
+    SyncParErrorOnMemAccess = 0b11001,
+    /// Synchronous parity or ECC error on translation table walk, level 1.
+    SyncParErrorOnTranslationTableWalkFirstLevel = 0b11100,
+    /// Synchronous parity or ECC error on translation table walk, level 2.
+    SyncParErrorOnTranslationTableWalkSecondLevel = 0b11110,
+}
+
+/// Fault status register enumeration for DFSR
+#[bitbybit::bitenum(u6, exhaustive = false)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v8-r")]
+#[derive(Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DfsrStatus {
+    /// Translation fault
+    Translation = 4,
+    /// Permission fault
+    Permission = 12,
+    /// Synchronous external abort, other than synchronous parity or ECC error
+    SyncExtAbort = 16,
+    /// SError interrupt
+    SErrorInterrupt = 17,
+    /// Synchronous parity or ECC error on memory access
+    SyncParityEccError = 24,
+    /// SError parity or ECC error on memory access
+    SErrorParityEccError = 25,
+    /// Alignment fault
+    AlignmentFault = 33,
+    /// Debug exception
+    Debug = 34,
 }
 
 impl SysReg for Dfsr {
@@ -60,11 +260,6 @@ impl SysReg for Dfsr {
 impl crate::register::SysRegRead for Dfsr {}
 
 impl Dfsr {
-    pub fn status(&self) -> Result<DfsrStatus, u8> {
-        let status = self.status_raw().as_u8();
-        DfsrStatus::try_from(status).map_err(|_| status)
-    }
-
     #[inline]
     /// Reads DFSR (*Data Fault Status Register*)
     pub fn read() -> Dfsr {
@@ -85,18 +280,5 @@ impl Dfsr {
         unsafe {
             <Self as SysRegWrite>::write_raw(value.raw_value());
         }
-    }
-}
-
-impl core::fmt::Debug for Dfsr {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "DFSR {{ ext={} wnr={} Domain={:#06b} Status={:#07b} }}",
-            self.ext(),
-            self.wnr(),
-            self.domain(),
-            self.status_raw()
-        )
     }
 }

--- a/aarch32-cpu/src/register/ifsr.rs
+++ b/aarch32-cpu/src/register/ifsr.rs
@@ -1,29 +1,151 @@
 //! Code for managing IFSR (*Instruction Fault Status Register*)
 
-use arbitrary_int::{prelude::*, u4, u5};
+#[allow(unused)]
+use arbitrary_int::u4;
 
 use crate::register::{SysReg, SysRegRead, SysRegWrite};
 
 /// IFSR (*Instruction Fault Status Register*)
-#[bitbybit::bitfield(u32, defmt_bitfields(feature = "defmt"))]
+#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v5te")]
 pub struct Ifsr {
-    /// External abort qualifier
-    #[bit(12, rw)]
-    ext: bool,
+    /// Which domain was being accessed
+    #[bits(4..=7, rw)]
+    domain: u4,
+    /// Status
+    #[bits([0..=3], rw)]
+    status: Option<IfsrStatus>,
+}
+
+/// IFSR (*Instruction Fault Status Register*)
+#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v6")]
+pub struct Ifsr {
+    /// Which domain was being accessed
+    #[bits(4..=7, rw)]
+    domain: u4,
+    /// Status bitfield.
+    #[bits([0..=3], rw)]
+    status: Option<IfsrStatus>,
+}
+
+/// IFSR (*Instruction Fault Status Register*)
+#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v7-r")]
+pub struct Ifsr {
+    /// AXI Decode or Slave
+    #[bit(12, r)]
+    sd: bool,
+    /// Which domain was being accessed
     #[bits(4..=7, rw)]
     domain: u4,
     /// Status bitfield.
     #[bits([0..=3, 10], rw)]
-    status_raw: u5,
+    status: Option<IfsrStatus>,
 }
 
-/// Fault status register enumeration for IFSR, which is also part of the DFSR
-#[derive(Debug, Copy, Clone, PartialEq, Eq, num_enum::TryFromPrimitive)]
+/// IFSR (*Instruction Fault Status Register*)
+#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v7-a")]
+pub struct Ifsr {
+    /// FAR not Valid
+    #[bit(16, rw)]
+    fnv: bool,
+    /// External Abort type
+    #[bit(12, rw)]
+    ext: bool,
+    /// Status bitfield.
+    #[bits([0..=3, 10], rw)]
+    status: Option<IfsrStatus>,
+}
+
+/// IFSR (*Instruction Fault Status Register*)
+#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(arm_architecture = "v8-r")]
+pub struct Ifsr {
+    /// FAR not Valid
+    #[bit(16, rw)]
+    fnv: bool,
+    /// External Abort type
+    #[bit(12, rw)]
+    ext: bool,
+    /// Status bitfield.
+    #[bits([0..=5], rw)]
+    status: Option<IfsrStatus>,
+}
+
+/// Fault status register enumeration for IFSR
+#[bitbybit::bitenum(u4, exhaustive = false)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[repr(u8)]
-pub enum FsrStatus {
+#[derive(Debug, PartialEq, Eq)]
+#[cfg(arm_architecture = "v5te")]
+pub enum IfsrStatus {
+    Alignment = 1,
+    DebugEvent = 2,
+    AlignmentAlt = 3,
+    TranslationFaultFirstLevel = 5,
+    TranslationFaultSecondLevel = 7,
+    SyncExtAbort = 8,
+    DomainFaultFirstLevel = 9,
+    SyncExtAbortAlt = 10,
+    DomainFaultSecondLevel = 11,
+    SyncExtAbortOnTranslationTableWalkFirstLevel = 12,
+    PermissionFaultFirstLevel = 13,
+    SyncExtAbortOnTranslationTableWalkSecondLevel = 14,
+    PermissionFaultSecondLevel = 15,
+}
+
+/// Fault status register enumeration for IFSR
+#[bitbybit::bitenum(u4, exhaustive = false)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg(arm_architecture = "v6")]
+pub enum IfsrStatus {
+    Alignment = 1,
+    DebugEvent = 2,
+    AccessFlagFaultFirstLevel = 3,
+    TranslationFaultFirstLevel = 5,
+    AccessFlagFaultSecondLevel = 6,
+    TranslationFaultSecondLevel = 7,
+    SyncExtAbort = 8,
+    DomainFaultFirstLevel = 9,
+    DomainFaultSecondLevel = 11,
+    SyncExtAbortOnTranslationTableWalkFirstLevel = 12,
+    PermissionFaultFirstLevel = 13,
+    SyncExtAbortOnTranslationTableWalkSecondLevel = 14,
+    PermissionFaultSecondLevel = 15,
+}
+
+/// Fault status register enumeration for IFSR
+#[bitbybit::bitenum(u5, exhaustive = false)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg(arm_architecture = "v7-r")]
+pub enum IfsrStatus {
+    Alignment = 1,
+    DebugEvent = 2,
+    SyncExtAbort = 8,
+    PermissionFaultFirstLevel = 13,
+    AsyncExtAbort = 21,
+    SyncParityEccError = 25,
+    AsyncParityEccError = 24,
+}
+
+/// Fault status register enumeration for IFSR
+#[bitbybit::bitenum(u5, exhaustive = false)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg(arm_architecture = "v7-a")]
+pub enum IfsrStatus {
     SyncExtAbortOnTranslationTableWalkFirstLevel = 0b01100,
     SyncExtAbortOnTranslationTableWalkSecondLevel = 0b01110,
     SyncParErrorOnTranslationTableWalkFirstLevel = 0b11100,
@@ -44,11 +166,19 @@ pub enum FsrStatus {
     SyncParErrorOnMemAccess = 0b11001,
 }
 
-impl Ifsr {
-    pub fn status(&self) -> Result<FsrStatus, u8> {
-        let status = self.status_raw().as_u8();
-        FsrStatus::try_from(status).map_err(|_| status)
-    }
+/// Fault status register enumeration for IFSR
+#[bitbybit::bitenum(u6, exhaustive = false)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg(arm_architecture = "v8-r")]
+pub enum IfsrStatus {
+    Translation = 4,
+    Permission = 12,
+    SyncExtAbort = 16,
+    SyncParityEccError = 24,
+    PcAlignment = 33,
+    Debug = 34,
 }
 
 impl SysReg for Ifsr {
@@ -82,17 +212,5 @@ impl Ifsr {
         unsafe {
             <Self as SysRegWrite>::write_raw(value.raw_value());
         }
-    }
-}
-
-impl core::fmt::Debug for Ifsr {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "IFSR {{ ext={} Domain={:#06b} Status={:#07b} }}",
-            self.ext(),
-            self.domain(),
-            self.status_raw()
-        )
     }
 }

--- a/aarch32-cpu/src/register/mod.rs
+++ b/aarch32-cpu/src/register/mod.rs
@@ -25,6 +25,7 @@ pub mod dccsw;
 pub mod dcimvac;
 pub mod dcisw;
 pub mod dfar;
+#[cfg(all(target_arch = "arm", not(arm_architecture = "v4t")))]
 pub mod dfsr;
 pub mod dlr;
 pub mod dracr;
@@ -50,6 +51,7 @@ pub mod id_mmfr4;
 pub mod id_pfr0;
 pub mod id_pfr1;
 pub mod ifar;
+#[cfg(all(target_arch = "arm", not(arm_architecture = "v4t")))]
 pub mod ifsr;
 pub mod imp;
 pub mod iracr;
@@ -125,6 +127,7 @@ pub use dccsw::Dccsw;
 pub use dcimvac::Dcimvac;
 pub use dcisw::Dcisw;
 pub use dfar::Dfar;
+#[cfg(all(target_arch = "arm", not(arm_architecture = "v4t")))]
 pub use dfsr::Dfsr;
 pub use dlr::Dlr;
 pub use dracr::Dracr;
@@ -150,6 +153,7 @@ pub use id_mmfr4::IdMmfr4;
 pub use id_pfr0::IdPfr0;
 pub use id_pfr1::IdPfr1;
 pub use ifar::Ifar;
+#[cfg(all(target_arch = "arm", not(arm_architecture = "v4t")))]
 pub use ifsr::Ifsr;
 pub use iracr::Iracr;
 pub use irbar::Irbar;

--- a/examples/mps3-an536/reference/abt-exception-a32-armv8r-none-eabihf.out
+++ b/examples/mps3-an536/reference/abt-exception-a32-armv8r-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0010 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught unaligned_from_a32
 caught fault on COUNTER
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0010 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught unaligned_from_a32
 caught fault on COUNTER
 Skipping instruction

--- a/examples/mps3-an536/reference/abt-exception-a32-thumbv8r-none-eabihf.out
+++ b/examples/mps3-an536/reference/abt-exception-a32-thumbv8r-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0010 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught unaligned_from_a32
 caught fault on COUNTER
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0010 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught unaligned_from_a32
 caught fault on COUNTER
 Skipping instruction

--- a/examples/mps3-an536/reference/abt-exception-t32-armv8r-none-eabihf.out
+++ b/examples/mps3-an536/reference/abt-exception-t32-armv8r-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0010 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught unaligned_from_t32
 caught fault on COUNTER
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0010 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught unaligned_from_t32
 caught fault on COUNTER
 Skipping instruction

--- a/examples/mps3-an536/reference/abt-exception-t32-thumbv8r-none-eabihf.out
+++ b/examples/mps3-an536/reference/abt-exception-t32-thumbv8r-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0010 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught unaligned_from_t32
 caught fault on COUNTER
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0010 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught unaligned_from_t32
 caught fault on COUNTER
 Skipping instruction

--- a/examples/mps3-an536/reference/prefetch-exception-a32-armv8r-none-eabihf.out
+++ b/examples/mps3-an536/reference/prefetch-exception-a32-armv8r-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0010 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(Debug) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0010 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(Debug) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction

--- a/examples/mps3-an536/reference/prefetch-exception-a32-thumbv8r-none-eabihf.out
+++ b/examples/mps3-an536/reference/prefetch-exception-a32-thumbv8r-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0010 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(Debug) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0010 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(Debug) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction

--- a/examples/mps3-an536/reference/prefetch-exception-t32-armv8r-none-eabihf.out
+++ b/examples/mps3-an536/reference/prefetch-exception-t32-armv8r-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0010 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(Debug) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0010 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(Debug) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction

--- a/examples/mps3-an536/reference/prefetch-exception-t32-thumbv8r-none-eabihf.out
+++ b/examples/mps3-an536/reference/prefetch-exception-t32-thumbv8r-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0010 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(Debug) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0010 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(Debug) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction

--- a/examples/mps3-an536/src/bin/abt-exception-a32.rs
+++ b/examples/mps3-an536/src/bin/abt-exception-a32.rs
@@ -87,7 +87,6 @@ unsafe fn data_abort_handler(addr: usize) -> usize {
     disable_alignment_check();
     let dfsr = Dfsr::read();
     println!("DFSR (Fault Status Register): {:?}", dfsr);
-    println!("DFSR Status: {:?}", dfsr.status());
     let dfar = Dfar::read();
     enable_alignment_check();
 

--- a/examples/mps3-an536/src/bin/abt-exception-t32.rs
+++ b/examples/mps3-an536/src/bin/abt-exception-t32.rs
@@ -87,7 +87,6 @@ unsafe fn data_abort_handler(addr: usize) -> usize {
     disable_alignment_check();
     let dfsr = Dfsr::read();
     println!("DFSR (Fault Status Register): {:?}", dfsr);
-    println!("DFSR Status: {:?}", dfsr.status());
     let dfar = Dfar::read();
     enable_alignment_check();
 

--- a/examples/mps3-an536/src/bin/prefetch-exception-a32.rs
+++ b/examples/mps3-an536/src/bin/prefetch-exception-a32.rs
@@ -60,7 +60,6 @@ unsafe fn prefetch_abort_handler(addr: usize) -> usize {
     println!("prefetch abort occurred");
     let ifsr = Ifsr::read();
     println!("IFSR (Fault Status Register): {:?}", ifsr);
-    println!("IFSR Status: {:?}", ifsr.status());
     let ifar = Ifar::read();
     println!("IFAR (Faulting Address Register): {:?}", ifar);
 

--- a/examples/mps3-an536/src/bin/prefetch-exception-t32.rs
+++ b/examples/mps3-an536/src/bin/prefetch-exception-t32.rs
@@ -59,7 +59,6 @@ unsafe fn prefetch_abort_handler(addr: usize) -> usize {
     println!("prefetch abort occurred");
     let ifsr = Ifsr::read();
     println!("IFSR (Fault Status Register): {:?}", ifsr);
-    println!("IFSR Status: {:?}", ifsr.status());
     let ifar = Ifar::read();
     println!("IFAR (Faulting Address Register): {:?}", ifar);
 

--- a/examples/versatileab/reference/abt-exception-a32-armv4t-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-a32-armv4t-none-eabi.out
@@ -1,14 +1,8 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
 caught unaligned_from_a32
-caught fault on COUNTER
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
 caught unaligned_from_a32
-caught fault on COUNTER
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-armv5te-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-a32-armv5te-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-armv6-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-a32-armv6-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { wnr: false, domain: 0, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { wnr: false, domain: 0, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-armv6-none-eabihf.out
+++ b/examples/versatileab/reference/abt-exception-a32-armv6-none-eabihf.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { wnr: false, domain: 0, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { wnr: false, domain: 0, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-armv7a-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-a32-armv7a-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-armv7a-none-eabihf.out
+++ b/examples/versatileab/reference/abt-exception-a32-armv7a-none-eabihf.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-armv7r-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-a32-armv7r-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-armv7r-none-eabihf.out
+++ b/examples/versatileab/reference/abt-exception-a32-armv7r-none-eabihf.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-thumbv4t-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-a32-thumbv4t-none-eabi.out
@@ -1,14 +1,8 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
 caught unaligned_from_a32
-caught fault on COUNTER
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
 caught unaligned_from_a32
-caught fault on COUNTER
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-thumbv5te-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-a32-thumbv5te-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-thumbv6-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-a32-thumbv6-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { wnr: false, domain: 0, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { wnr: false, domain: 0, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-thumbv7a-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-a32-thumbv7a-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-thumbv7a-none-eabihf.out
+++ b/examples/versatileab/reference/abt-exception-a32-thumbv7a-none-eabihf.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-thumbv7r-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-a32-thumbv7r-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-a32-thumbv7r-none-eabihf.out
+++ b/examples/versatileab/reference/abt-exception-a32-thumbv7r-none-eabihf.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_a32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-armv4t-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-t32-armv4t-none-eabi.out
@@ -1,14 +1,8 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
 caught unaligned_from_t32
-caught fault on COUNTER
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
 caught unaligned_from_t32
-caught fault on COUNTER
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-armv5te-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-t32-armv5te-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-armv6-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-t32-armv6-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { wnr: false, domain: 0, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { wnr: false, domain: 0, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-armv6-none-eabihf.out
+++ b/examples/versatileab/reference/abt-exception-t32-armv6-none-eabihf.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { wnr: false, domain: 0, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { wnr: false, domain: 0, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-armv7a-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-t32-armv7a-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-armv7a-none-eabihf.out
+++ b/examples/versatileab/reference/abt-exception-t32-armv7a-none-eabihf.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-armv7r-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-t32-armv7r-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-armv7r-none-eabihf.out
+++ b/examples/versatileab/reference/abt-exception-t32-armv7r-none-eabihf.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-thumbv4t-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-t32-thumbv4t-none-eabi.out
@@ -1,14 +1,8 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
 caught unaligned_from_t32
-caught fault on COUNTER
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
 caught unaligned_from_t32
-caught fault on COUNTER
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-thumbv5te-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-t32-thumbv5te-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-thumbv6-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-t32-thumbv6-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { wnr: false, domain: 0, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { wnr: false, domain: 0, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-thumbv7a-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-t32-thumbv7a-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-thumbv7a-none-eabihf.out
+++ b/examples/versatileab/reference/abt-exception-t32-thumbv7a-none-eabihf.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { fnv: false, cm: false, ext: false, wnr: false, status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-thumbv7r-none-eabi.out
+++ b/examples/versatileab/reference/abt-exception-t32-thumbv7r-none-eabi.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/abt-exception-t32-thumbv7r-none-eabihf.out
+++ b/examples/versatileab/reference/abt-exception-t32-thumbv7r-none-eabihf.out
@@ -1,14 +1,12 @@
 Hello, this is an data abort exception example
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Doing it again
 data abort occurred
-DFSR (Fault Status Register): DFSR { ext=false wnr=false Domain=0b0000 Status=0b00001 }
-DFSR Status: Ok(AlignmentFault)
-caught unaligned_from_t32
+DFSR (Fault Status Register): Dfsr { status: Ok(AlignmentFault) }
 caught fault on COUNTER
+caught unaligned_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-a32-armv4t-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-armv4t-none-eabi.out
@@ -1,12 +1,8 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
 caught bkpt_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-a32-armv5te-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-armv5te-none-eabi.out
@@ -1,12 +1,10 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
 caught bkpt_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-a32-armv6-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-armv6-none-eabi.out
@@ -1,12 +1,12 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
+IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
+IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-a32-armv6-none-eabihf.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-armv6-none-eabihf.out
@@ -1,12 +1,12 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
+IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
+IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-a32-armv7a-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-armv7a-none-eabi.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-a32-armv7a-none-eabihf.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-armv7a-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-a32-armv7r-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-armv7r-none-eabi.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-a32-armv7r-none-eabihf.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-armv7r-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-a32-thumbv4t-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-thumbv4t-none-eabi.out
@@ -1,12 +1,8 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
 caught bkpt_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-a32-thumbv5te-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-thumbv5te-none-eabi.out
@@ -1,12 +1,10 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
 caught bkpt_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-a32-thumbv6-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-thumbv6-none-eabi.out
@@ -1,12 +1,12 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
+IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
+IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-a32-thumbv7a-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-thumbv7a-none-eabi.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-a32-thumbv7a-none-eabihf.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-thumbv7a-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-a32-thumbv7r-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-thumbv7r-none-eabi.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-a32-thumbv7r-none-eabihf.out
+++ b/examples/versatileab/reference/prefetch-exception-a32-thumbv7r-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_a32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-t32-armv4t-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-armv4t-none-eabi.out
@@ -1,12 +1,8 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
 caught bkpt_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-t32-armv5te-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-armv5te-none-eabi.out
@@ -1,12 +1,10 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
 caught bkpt_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-t32-armv6-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-armv6-none-eabi.out
@@ -1,12 +1,12 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
+IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
+IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-t32-armv6-none-eabihf.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-armv6-none-eabihf.out
@@ -1,12 +1,12 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
+IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
+IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-t32-armv7a-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-armv7a-none-eabi.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-t32-armv7a-none-eabihf.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-armv7a-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-t32-armv7r-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-armv7r-none-eabi.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-t32-armv7r-none-eabihf.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-armv7r-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-t32-thumbv4t-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-thumbv4t-none-eabi.out
@@ -1,12 +1,8 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
 caught bkpt_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-t32-thumbv5te-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-thumbv5te-none-eabi.out
@@ -1,12 +1,10 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
 caught bkpt_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-t32-thumbv6-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-thumbv6-none-eabi.out
@@ -1,12 +1,12 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
+IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { domain: 0, status: Ok(DebugEvent) }
+IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction
 Recovered from fault OK!

--- a/examples/versatileab/reference/prefetch-exception-t32-thumbv7a-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-thumbv7a-none-eabi.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-t32-thumbv7a-none-eabihf.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-thumbv7a-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { fnv: false, ext: false, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-t32-thumbv7r-none-eabi.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-thumbv7r-none-eabi.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction

--- a/examples/versatileab/reference/prefetch-exception-t32-thumbv7r-none-eabihf.out
+++ b/examples/versatileab/reference/prefetch-exception-t32-thumbv7r-none-eabihf.out
@@ -1,13 +1,11 @@
 Hello, this is a prefetch abort exception example
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Doing it again
 prefetch abort occurred
-IFSR (Fault Status Register): IFSR { ext=false Domain=0b0000 Status=0b00010 }
-IFSR Status: Ok(DebugEvent)
+IFSR (Fault Status Register): Ifsr { sd: false, domain: 0, status: Ok(DebugEvent) }
 IFAR (Faulting Address Register): Ifar(0)
 caught bkpt_from_t32
 Skipping instruction

--- a/examples/versatileab/src/bin/abt-exception-a32.rs
+++ b/examples/versatileab/src/bin/abt-exception-a32.rs
@@ -5,7 +5,9 @@
 
 use portable_atomic::{AtomicU32, Ordering};
 
-use aarch32_cpu::register::{Dfar, Dfsr, Sctlr};
+use aarch32_cpu::register::Sctlr;
+#[cfg(not(arm_architecture = "v4t"))]
+use aarch32_cpu::register::{Dfar, Dfsr};
 use aarch32_rt::{entry, exception};
 use semihosting::println;
 use versatileab as _;
@@ -83,14 +85,28 @@ fn prefetch_abort_handler(_addr: usize) -> ! {
 #[exception(DataAbort)]
 unsafe fn data_abort_handler(addr: usize) -> usize {
     println!("data abort occurred");
-    // If this is not disabled, reading DFAR will trigger an alignment fault on Armv8-R, leading
-    // to a loop.
-    disable_alignment_check();
-    let dfsr = Dfsr::read();
-    println!("DFSR (Fault Status Register): {:?}", dfsr);
-    println!("DFSR Status: {:?}", dfsr.status());
-    let dfar = Dfar::read();
-    enable_alignment_check();
+
+    #[cfg(not(arm_architecture = "v4t"))]
+    {
+        // If this is not disabled, reading DFAR will trigger an alignment fault on Armv8-R, leading
+        // to a loop.
+        disable_alignment_check();
+        let dfsr = Dfsr::read();
+        println!("DFSR (Fault Status Register): {:?}", dfsr);
+        let dfar = Dfar::read();
+        enable_alignment_check();
+
+        let expect_fault_from = core::ptr::addr_of!(COUNTER) as usize + 1;
+
+        if dfar.0 as usize == expect_fault_from {
+            println!("caught fault on COUNTER");
+        } else {
+            println!(
+                "Bad DFAR address {:08x} is not {:08x}",
+                dfar.0, expect_fault_from
+            );
+        }
+    }
 
     // note the fault isn't at the start of the function
     let expect_fault_at = unaligned_from_a32 as unsafe extern "C" fn() as usize + 8;
@@ -101,17 +117,6 @@ unsafe fn data_abort_handler(addr: usize) -> usize {
         println!(
             "Bad fault address {:08x} is not {:08x}",
             addr, expect_fault_at
-        );
-    }
-
-    let expect_fault_from = core::ptr::addr_of!(COUNTER) as usize + 1;
-
-    if dfar.0 as usize == expect_fault_from {
-        println!("caught fault on COUNTER");
-    } else {
-        println!(
-            "Bad DFAR address {:08x} is not {:08x}",
-            dfar.0, expect_fault_from
         );
     }
 

--- a/examples/versatileab/src/bin/abt-exception-t32.rs
+++ b/examples/versatileab/src/bin/abt-exception-t32.rs
@@ -5,7 +5,9 @@
 
 use portable_atomic::{AtomicU32, Ordering};
 
-use aarch32_cpu::register::{Dfar, Dfsr, Sctlr};
+use aarch32_cpu::register::Sctlr;
+#[cfg(not(arm_architecture = "v4t"))]
+use aarch32_cpu::register::{Dfar, Dfsr};
 use aarch32_rt::{entry, exception};
 use semihosting::println;
 use versatileab as _;
@@ -83,14 +85,28 @@ fn prefetch_abort_handler(_addr: usize) -> ! {
 #[exception(DataAbort)]
 unsafe fn data_abort_handler(addr: usize) -> usize {
     println!("data abort occurred");
-    // If this is not disabled, reading DFAR will trigger an alignment fault on Armv8-R, leading
-    // to a loop.
-    disable_alignment_check();
-    let dfsr = Dfsr::read();
-    println!("DFSR (Fault Status Register): {:?}", dfsr);
-    println!("DFSR Status: {:?}", dfsr.status());
-    let dfar = Dfar::read();
-    enable_alignment_check();
+
+    #[cfg(not(arm_architecture = "v4t"))]
+    {
+        // If this is not disabled, reading DFAR will trigger an alignment fault on Armv8-R, leading
+        // to a loop.
+        disable_alignment_check();
+        let dfsr = Dfsr::read();
+        println!("DFSR (Fault Status Register): {:?}", dfsr);
+        let dfar = Dfar::read();
+        enable_alignment_check();
+
+        let expect_fault_from = core::ptr::addr_of!(COUNTER) as usize + 1;
+
+        if dfar.0 as usize == expect_fault_from {
+            println!("caught fault on COUNTER");
+        } else {
+            println!(
+                "Bad DFAR address {:08x} is not {:08x}",
+                dfar.0, expect_fault_from
+            );
+        }
+    }
 
     // note the fault isn't at the start of the function
     let expect_fault_at = unaligned_from_t32 as unsafe extern "C" fn() as usize + 3;
@@ -101,17 +117,6 @@ unsafe fn data_abort_handler(addr: usize) -> usize {
         println!(
             "Bad fault address {:08x} is not {:08x}",
             addr, expect_fault_at
-        );
-    }
-
-    let expect_fault_from = core::ptr::addr_of!(COUNTER) as usize + 1;
-
-    if dfar.0 as usize == expect_fault_from {
-        println!("caught fault on COUNTER");
-    } else {
-        println!(
-            "Bad DFAR address {:08x} is not {:08x}",
-            dfar.0, expect_fault_from
         );
     }
 

--- a/examples/versatileab/src/bin/prefetch-exception-a32.rs
+++ b/examples/versatileab/src/bin/prefetch-exception-a32.rs
@@ -5,7 +5,10 @@
 
 use portable_atomic::{AtomicU32, Ordering};
 
-use aarch32_cpu::register::{Ifar, Ifsr};
+#[cfg(not(any(arm_architecture = "v4t", arm_architecture = "v5te")))]
+use aarch32_cpu::register::Ifar;
+#[cfg(not(arm_architecture = "v4t"))]
+use aarch32_cpu::register::Ifsr;
 use aarch32_rt::{entry, exception};
 use semihosting::println;
 use versatileab as _;
@@ -58,15 +61,14 @@ fn undefined_handler(addr: usize) -> ! {
 #[exception(PrefetchAbort)]
 unsafe fn prefetch_abort_handler(addr: usize) -> usize {
     println!("prefetch abort occurred");
-    let ifsr = Ifsr::read();
-    println!("IFSR (Fault Status Register): {:?}", ifsr);
-    println!("IFSR Status: {:?}", ifsr.status());
 
-    if cfg!(not(any(
-        arm_architecture = "v4t",
-        arm_architecture = "v5te",
-        arm_architecture = "v6"
-    ))) {
+    #[cfg(not(arm_architecture = "v4t"))]
+    {
+        let ifsr = Ifsr::read();
+        println!("IFSR (Fault Status Register): {:?}", ifsr);
+    }
+    #[cfg(not(any(arm_architecture = "v4t", arm_architecture = "v5te")))]
+    {
         let ifar = Ifar::read();
         println!("IFAR (Faulting Address Register): {:?}", ifar);
     }

--- a/examples/versatileab/src/bin/prefetch-exception-t32.rs
+++ b/examples/versatileab/src/bin/prefetch-exception-t32.rs
@@ -5,7 +5,10 @@
 
 use portable_atomic::{AtomicU32, Ordering};
 
-use aarch32_cpu::register::{Ifar, Ifsr};
+#[cfg(not(any(arm_architecture = "v4t", arm_architecture = "v5te")))]
+use aarch32_cpu::register::Ifar;
+#[cfg(not(arm_architecture = "v4t"))]
+use aarch32_cpu::register::Ifsr;
 use aarch32_rt::{entry, exception};
 use semihosting::println;
 use versatileab as _;
@@ -58,15 +61,14 @@ fn undefined_handler(_addr: usize) -> ! {
 #[exception(PrefetchAbort)]
 unsafe fn prefetch_abort_handler(addr: usize) -> usize {
     println!("prefetch abort occurred");
-    let ifsr = Ifsr::read();
-    println!("IFSR (Fault Status Register): {:?}", ifsr);
-    println!("IFSR Status: {:?}", ifsr.status());
 
-    if cfg!(not(any(
-        arm_architecture = "v4t",
-        arm_architecture = "v5te",
-        arm_architecture = "v6"
-    ))) {
+    #[cfg(not(arm_architecture = "v4t"))]
+    {
+        let ifsr = Ifsr::read();
+        println!("IFSR (Fault Status Register): {:?}", ifsr);
+    }
+    #[cfg(not(any(arm_architecture = "v4t", arm_architecture = "v5te")))]
+    {
         let ifar = Ifar::read();
         println!("IFAR (Faulting Address Register): {:?}", ifar);
     }


### PR DESCRIPTION
Closes #132

I don't love the implementation I chose, but it works and at least we have good test coverage across all the targets to make sure I didn't miss any particular target out.
