### PR TITLE
Nicer MAIR syntax

### DIFF
--- a/aarch32-cpu/src/pmsav8.rs
+++ b/aarch32-cpu/src/pmsav8.rs
@@ -137,21 +137,27 @@ impl El1Mpu {
     /// Set the memory attributes to MAIR0 and MAIR1
     #[allow(clippy::get_first)]
     pub fn set_attributes(&mut self, memattrs: &[MemAttr]) {
-        let mem_attr0 = memattrs.get(0).map(|m| m.to_bits()).unwrap_or(0) as u32;
-        let mem_attr1 = memattrs.get(1).map(|m| m.to_bits()).unwrap_or(0) as u32;
-        let mem_attr2 = memattrs.get(2).map(|m| m.to_bits()).unwrap_or(0) as u32;
-        let mem_attr3 = memattrs.get(3).map(|m| m.to_bits()).unwrap_or(0) as u32;
-        let mair0 = mem_attr3 << 24 | mem_attr2 << 16 | mem_attr1 << 8 | mem_attr0;
+        let mair0 = register::Mair::builder()
+            .with_attrs([
+                memattrs.get(0).map(|m| m.to_bits()).unwrap_or(0),
+                memattrs.get(1).map(|m| m.to_bits()).unwrap_or(0),
+                memattrs.get(2).map(|m| m.to_bits()).unwrap_or(0),
+                memattrs.get(3).map(|m| m.to_bits()).unwrap_or(0),
+            ])
+            .build();
         unsafe {
-            register::Mair0::write(register::Mair0(mair0));
+            register::Mair0::write(mair0);
         }
-        let mem_attr0 = memattrs.get(4).map(|m| m.to_bits()).unwrap_or(0) as u32;
-        let mem_attr1 = memattrs.get(5).map(|m| m.to_bits()).unwrap_or(0) as u32;
-        let mem_attr2 = memattrs.get(6).map(|m| m.to_bits()).unwrap_or(0) as u32;
-        let mem_attr3 = memattrs.get(7).map(|m| m.to_bits()).unwrap_or(0) as u32;
-        let mair1 = mem_attr3 << 24 | mem_attr2 << 16 | mem_attr1 << 8 | mem_attr0;
+        let mair1 = register::Mair::builder()
+            .with_attrs([
+                memattrs.get(4).map(|m| m.to_bits()).unwrap_or(0),
+                memattrs.get(5).map(|m| m.to_bits()).unwrap_or(0),
+                memattrs.get(6).map(|m| m.to_bits()).unwrap_or(0),
+                memattrs.get(7).map(|m| m.to_bits()).unwrap_or(0),
+            ])
+            .build();
         unsafe {
-            register::Mair1::write(register::Mair1(mair1));
+            register::Mair1::write(mair1);
         }
     }
 

--- a/aarch32-cpu/src/register/bpiall.rs
+++ b/aarch32-cpu/src/register/bpiall.rs
@@ -1,8 +1,8 @@
-//! BPIALL: Invalidate all entries from branch predictors
+//! Code for managing BPIALL (*Branch Predictor Invalidate All*)
 
 use crate::register::SysReg;
 
-/// BPIALL: Invalidate all entries from branch predictors
+/// BPIALL (*Branch Predictor Invalidate All*)
 pub struct BpIAll;
 
 impl SysReg for BpIAll {

--- a/aarch32-cpu/src/register/dc_sw_ops.rs
+++ b/aarch32-cpu/src/register/dc_sw_ops.rs
@@ -1,3 +1,7 @@
+//! Code for managing Data Cache Set/Way Operations
+//!
+//! Used by DCCISW, DCCSW and DCISW registers.
+
 use arbitrary_int::u3;
 
 /// Create input data register value for cache maintenance operations by set and way.

--- a/aarch32-cpu/src/register/dccimvac.rs
+++ b/aarch32-cpu/src/register/dccimvac.rs
@@ -1,4 +1,5 @@
-//! DCCIMVAC (*Clean And Invalidate Data Cache Or Unified Cache Line by MVA to Point of Coherence.*)
+//! Code for managing DCCIMVAC (*Clean And Invalidate Data Cache Or Unified Cache Line by MVA to Point of Coherence.*)
+
 use crate::register::{SysReg, SysRegWrite};
 
 #[derive(Debug, Copy, Clone)]

--- a/aarch32-cpu/src/register/dccisw.rs
+++ b/aarch32-cpu/src/register/dccisw.rs
@@ -1,4 +1,4 @@
-//! DCCISW (*Clean and Invalidate Data or Unified cache line by Set/Way.*)
+//! Code for managing DCCISW (*Clean and Invalidate Data or Unified cache line by Set/Way.*)
 
 use arbitrary_int::u3;
 

--- a/aarch32-cpu/src/register/dccmvac.rs
+++ b/aarch32-cpu/src/register/dccmvac.rs
@@ -1,4 +1,5 @@
-//! DCCMVAC (*Clean Data Cache Or Unified Cache Line by MVA to Point of Coherence.*)
+//! Code for managing DCCMVAC (*Clean Data Cache Or Unified Cache Line by MVA to Point of Coherence.*)
+
 use crate::register::{SysReg, SysRegWrite};
 
 #[derive(Debug, Copy, Clone)]

--- a/aarch32-cpu/src/register/dccmvau.rs
+++ b/aarch32-cpu/src/register/dccmvau.rs
@@ -1,4 +1,5 @@
-//! DCCMVAU (*Clean Data Cache Or Unified Cache Line by MVA to Point of Unification.*)
+//! Code for managing DCCMVAU (*Clean Data Cache Or Unified Cache Line by MVA to Point of Unification.*)
+
 use crate::register::{SysReg, SysRegWrite};
 
 #[derive(Debug, Copy, Clone)]

--- a/aarch32-cpu/src/register/dccsw.rs
+++ b/aarch32-cpu/src/register/dccsw.rs
@@ -1,4 +1,4 @@
-//! DCCSW (*Clean Data or Unified Cache line by Set/Way.*)
+//! Code for managing DCCSW (*Clean Data or Unified Cache line by Set/Way.*)
 
 use arbitrary_int::u3;
 

--- a/aarch32-cpu/src/register/dcimvac.rs
+++ b/aarch32-cpu/src/register/dcimvac.rs
@@ -1,4 +1,5 @@
-//! DCIMVAC (*Invalidate Data Cache Or Unified Cache Line by MVA to Point of Coherence.*)
+//! Code for managing DCIMVAC (*Invalidate Data Cache Or Unified Cache Line by MVA to Point of Coherence.*)
+
 use crate::register::{SysReg, SysRegWrite};
 
 #[derive(Debug, Copy, Clone)]

--- a/aarch32-cpu/src/register/dcisw.rs
+++ b/aarch32-cpu/src/register/dcisw.rs
@@ -1,4 +1,4 @@
-//! DCISW (*Invalidate Data or Unified Cache line by Set/Way.*)
+//! Code for managing DCISW (*Invalidate Data or Unified Cache line by Set/Way.*)
 
 use arbitrary_int::u3;
 

--- a/aarch32-cpu/src/register/iciallu.rs
+++ b/aarch32-cpu/src/register/iciallu.rs
@@ -1,4 +1,4 @@
-//! ICIALLU (*Invalidate all instruction caches to PoU.*)
+//! Code for managing ICIALLU (*Invalidate all instruction caches to PoU.*)
 //!
 //! Starting with ARMv6, the type of cache can be determined from the System Coprocessor register 0,
 //! and controlled through registers 1, 7 and 9. In earlier architecture variants, it is

--- a/aarch32-cpu/src/register/mair0.rs
+++ b/aarch32-cpu/src/register/mair0.rs
@@ -2,11 +2,20 @@
 
 use crate::register::{SysReg, SysRegRead, SysRegWrite};
 
+/// MAIR (*Memory Attribute Indirection Register*) value for MAIR0 or MAIR1
+#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Mair {
+    /// The four MAIR attributes held in a 32-bit MAIR register
+    #[bits(0..=7, rw)]
+    attrs: [u8; 4],
+}
+
 /// MAIR0 (*Memory Attribute Indirection Register 0*)
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Mair0(pub u32);
+pub struct Mair0;
 
 impl SysReg for Mair0 {
     const CP: u32 = 15;
@@ -21,8 +30,8 @@ impl crate::register::SysRegRead for Mair0 {}
 impl Mair0 {
     #[inline]
     /// Reads MAIR0 (*Memory Attribute Indirection Register 0*)
-    pub fn read() -> Mair0 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Mair {
+        unsafe { Mair::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +44,9 @@ impl Mair0 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Mair) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/mair1.rs
+++ b/aarch32-cpu/src/register/mair1.rs
@@ -1,12 +1,13 @@
 //! Code for managing MAIR1 (*Memory Attribute Indirection Register 1*)
 
+use super::Mair;
 use crate::register::{SysReg, SysRegRead, SysRegWrite};
 
 /// MAIR1 (*Memory Attribute Indirection Register 1*)
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Mair1(pub u32);
+pub struct Mair1;
 
 impl SysReg for Mair1 {
     const CP: u32 = 15;
@@ -21,8 +22,8 @@ impl crate::register::SysRegRead for Mair1 {}
 impl Mair1 {
     #[inline]
     /// Reads MAIR1 (*Memory Attribute Indirection Register 1*)
-    pub fn read() -> Mair1 {
-        unsafe { Self(<Self as SysRegRead>::read_raw()) }
+    pub fn read() -> Mair {
+        unsafe { Mair::new_with_raw_value(<Self as SysRegRead>::read_raw()) }
     }
 }
 
@@ -35,9 +36,9 @@ impl Mair1 {
     /// # Safety
     ///
     /// Ensure that this value is appropriate for this register
-    pub unsafe fn write(value: Self) {
+    pub unsafe fn write(value: Mair) {
         unsafe {
-            <Self as SysRegWrite>::write_raw(value.0);
+            <Self as SysRegWrite>::write_raw(value.raw_value());
         }
     }
 }

--- a/aarch32-cpu/src/register/mod.rs
+++ b/aarch32-cpu/src/register/mod.rs
@@ -158,7 +158,7 @@ pub use ifsr::Ifsr;
 pub use iracr::Iracr;
 pub use irbar::Irbar;
 pub use irsr::Irsr;
-pub use mair0::Mair0;
+pub use mair0::{Mair, Mair0};
 pub use mair1::Mair1;
 pub use midr::Midr;
 pub use mpidr::Mpidr;

--- a/aarch32-cpu/src/register/tlbiall.rs
+++ b/aarch32-cpu/src/register/tlbiall.rs
@@ -1,4 +1,4 @@
-//! TLBIALL (*TLB Invalidate All Register*)
+//! Code for managing TLBIALL (*TLB Invalidate All Register*)
 
 use crate::register::SysReg;
 


### PR DESCRIPTION
- Switch MAIR0 and MAIR1 to use same type (MAIR)
- Switch MAIR to use an array
- Revise a bunch of unrelated module comments so the `cargo doc` output looks nice
