### PR TITLE
Make docs.rs build more docs

### DIFF
--- a/aarch32-cpu/Cargo.toml
+++ b/aarch32-cpu/Cargo.toml
@@ -51,4 +51,11 @@ serde = ["dep:serde", "arbitrary-int/serde"]
 check-asm = []
 
 [package.metadata.docs.rs]
-targets = ["armv7r-none-eabihf", "armv7r-none-eabi", "armv7a-none-eabihf"]
+# This is a list of supported Tier 2 targets, as of latest stable
+targets = [
+    "armv7r-none-eabihf",
+    "armv7r-none-eabi",
+    "armv7a-none-eabihf",
+    "armv7a-none-eabi",
+    "armv8r-none-eabihf"
+]

--- a/aarch32-rt/Cargo.toml
+++ b/aarch32-rt/Cargo.toml
@@ -40,4 +40,11 @@ fpu-d32 = []
 arm-targets = { version = "0.4.0", path = "../arm-targets" }
 
 [package.metadata.docs.rs]
-targets = ["armv7r-none-eabihf", "armv7r-none-eabihf", "armv7a-none-eabi"]
+# This is a list of supported Tier 2 targets, as of latest stable
+targets = [
+    "armv7r-none-eabihf",
+    "armv7r-none-eabi",
+    "armv7a-none-eabihf",
+    "armv7a-none-eabi",
+    "armv8r-none-eabihf"
+]


### PR DESCRIPTION
Simple change - tell docs.rs to build for all stable tier 2 targets.

Closes #145 