### PR TITLE
Remove more nightly Rust.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,9 @@ jobs:
         uses: taiki-e/install-action@just
       - name: Install Rust
         run: |
-          rustup install nightly-2026-02-26
-          rustup component add rust-src --toolchain nightly-2026-02-26
-          rustup default nightly-2026-02-26
+          rustup install stable
+          rustup default stable
+          rustup component add rust-src
       - name: Build
         run: |
           just build-tier3 ${{ matrix.target }}
@@ -89,9 +89,9 @@ jobs:
         uses: taiki-e/install-action@just
       - name: Install Rust
         run: |
-          rustup install nightly-2026-02-26
-          rustup component add rust-src --toolchain nightly-2026-02-26
-          rustup default nightly-2026-02-26
+          rustup install stable
+          rustup default stable
+          rustup component add rust-src
       - name: Build
         run: |
           just build-tier3-no-atomics ${{ matrix.target }}

--- a/justfile
+++ b/justfile
@@ -11,7 +11,6 @@ export RUSTC_BOOTSTRAP := "1"
 # If you run with `just --set v 1` then we make cargo run in verbose mode
 v := "0"
 verbose := if v == "1" { "--verbose" } else { "" }
-nightly := "nightly-2026-02-26"
 
 # Our default target. It does everything that you might want to do pre-checkin.
 check: build-all build-all-examples fmt-check clippy-examples clippy-targets clippy-host test
@@ -57,14 +56,14 @@ build-arm-targets:
 
 # Builds our workspace with various features, building core from source, but skipping anything that requires atomics
 build-tier3-no-atomics target:
-    cargo +{{nightly}} build --target {{target}} -Zbuild-std=core {{verbose}}
-    cargo +{{nightly}} build --target {{target}} -Zbuild-std=core --features "serde, defmt, critical-section-single-core, check-asm" {{verbose}}
+    cargo build --target {{target}} -Zbuild-std=core {{verbose}}
+    cargo build --target {{target}} -Zbuild-std=core --features "serde, defmt, critical-section-single-core, check-asm" {{verbose}}
 
 # Builds our workspace with various features, building core from source
 build-tier3 target:
-    cargo +{{nightly}} build --target {{target}} -Zbuild-std=core {{verbose}}
-    cargo +{{nightly}} build --target {{target}} -Zbuild-std=core --features "serde, defmt, critical-section-multi-core, check-asm" {{verbose}}
-    cargo +{{nightly}} build --target {{target}} -Zbuild-std=core --features "serde, defmt, critical-section-single-core, check-asm" {{verbose}}
+    cargo build --target {{target}} -Zbuild-std=core {{verbose}}
+    cargo build --target {{target}} -Zbuild-std=core --features "serde, defmt, critical-section-multi-core, check-asm" {{verbose}}
+    cargo build --target {{target}} -Zbuild-std=core --features "serde, defmt, critical-section-single-core, check-asm" {{verbose}}
 
 # Builds our workspace with various features
 build-tier2 target:


### PR DESCRIPTION
It all works on stable now (with RUSTC_BOOTSTRAP=1 for building libcore from source), so just use stable rust.