### PR TITLE
Update arm-gic to 0.8

### DIFF
--- a/examples/mps3-an536-el2/Cargo.toml
+++ b/examples/mps3-an536-el2/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.0.0"
 [dependencies]
 aarch32-cpu = { path = "../../aarch32-cpu", features = ["critical-section-multi-core"] }
 aarch32-rt = { path = "../../aarch32-rt", features = ["el2-mode"] }
-arm-gic = { version = "0.7.1" }
+arm-gic = "0.8.1"
 critical-section = "1.2.0"
 heapless = "0.9.1"
 libm = "0.2.15"

--- a/examples/mps3-an536-el2/src/bin/generic-timer.rs
+++ b/examples/mps3-an536-el2/src/bin/generic-timer.rs
@@ -7,7 +7,10 @@ use core::sync::atomic::{AtomicU32, Ordering::Relaxed};
 
 use aarch32_cpu::generic_timer::GenericTimer;
 use aarch32_rt::{entry, exception, irq};
-use arm_gic::gicv3::{GicCpuInterface, Group, InterruptGroup};
+use arm_gic::{
+    InterruptGroup,
+    gicv3::{GicCpuInterface, Group},
+};
 use semihosting::println;
 
 use mps3_an536_el2::HYP_TIMER_PPI;

--- a/examples/mps3-an536-smp/Cargo.toml
+++ b/examples/mps3-an536-smp/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.0.0"
 [dependencies]
 aarch32-cpu = { path = "../../aarch32-cpu", features = ["critical-section-multi-core"] }
 aarch32-rt = { path = "../../aarch32-rt" }
-arm-gic = { version = "0.7.1" }
+arm-gic = "0.8.1"
 critical-section = "1.2.0"
 heapless = "0.9.1"
 libm = "0.2.15"

--- a/examples/mps3-an536-smp/src/bin/gic.rs
+++ b/examples/mps3-an536-smp/src/bin/gic.rs
@@ -7,8 +7,8 @@ use core::cell::RefCell;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use arm_gic::{
-    IntId,
-    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
+    gicv3::{GicCpuInterface, Group, SgiTarget, SgiTargetGroup},
+    {IntId, InterruptGroup},
 };
 use critical_section::Mutex;
 use semihosting::println;

--- a/examples/mps3-an536/Cargo.toml
+++ b/examples/mps3-an536/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.0.0"
 [dependencies]
 aarch32-cpu = { path = "../../aarch32-cpu", features = ["critical-section-multi-core"] }
 aarch32-rt = { path = "../../aarch32-rt" }
-arm-gic = { version = "0.7.1" }
+arm-gic = "0.8.1"
 critical-section = "1.2.0"
 heapless = "0.9.1"
 libm = "0.2.15"

--- a/examples/mps3-an536/src/bin/generic_timer_irq.rs
+++ b/examples/mps3-an536/src/bin/generic_timer_irq.rs
@@ -5,7 +5,10 @@
 
 use aarch32_cpu::generic_timer::{El1VirtualTimer, GenericTimer};
 use aarch32_rt::{entry, irq};
-use arm_gic::gicv3::{GicCpuInterface, Group, InterruptGroup};
+use arm_gic::{
+    InterruptGroup,
+    gicv3::{GicCpuInterface, Group},
+};
 use mps3_an536::VIRTUAL_TIMER_PPI;
 use semihosting::println;
 

--- a/examples/mps3-an536/src/bin/gic-map.rs
+++ b/examples/mps3-an536/src/bin/gic-map.rs
@@ -9,8 +9,8 @@ use core::cell::RefCell;
 
 use aarch32_rt::{entry, irq};
 use arm_gic::{
-    IntId,
-    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
+    gicv3::{GicCpuInterface, Group, SgiTarget, SgiTargetGroup},
+    {IntId, InterruptGroup},
 };
 use heapless::linear_map::LinearMap;
 use mps3_an536::InterruptHandler;

--- a/examples/mps3-an536/src/bin/gic-priority-ceiling.rs
+++ b/examples/mps3-an536/src/bin/gic-priority-ceiling.rs
@@ -5,8 +5,8 @@
 
 use aarch32_rt::{entry, irq};
 use arm_gic::{
-    IntId,
-    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
+    gicv3::{GicCpuInterface, Group, SgiTarget, SgiTargetGroup},
+    {IntId, InterruptGroup},
 };
 use mps3_an536 as _;
 use semihosting::println;

--- a/examples/mps3-an536/src/bin/gic-static-section-irq.rs
+++ b/examples/mps3-an536/src/bin/gic-static-section-irq.rs
@@ -7,8 +7,8 @@
 
 use aarch32_rt::{entry, irq};
 use arm_gic::{
-    IntId,
-    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
+    gicv3::{GicCpuInterface, Group, SgiTarget, SgiTargetGroup},
+    {IntId, InterruptGroup},
 };
 use mps3_an536::InterruptHandler;
 use semihosting::println;

--- a/examples/mps3-an536/src/bin/gic-unified-irq.rs
+++ b/examples/mps3-an536/src/bin/gic-unified-irq.rs
@@ -7,8 +7,8 @@
 
 use aarch32_rt::{entry, irq};
 use arm_gic::{
-    IntId,
-    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
+    gicv3::{GicCpuInterface, Group, SgiTarget, SgiTargetGroup},
+    {IntId, InterruptGroup},
 };
 use mps3_an536 as _;
 use semihosting::println;


### PR DESCRIPTION
Updates to latest arm-gic crate.

This is the first version to use arm-sysregs. Earlier versions of arm-sysregs were broken on AArch32, so I wanted to make sure we were now testing the latest version to make sure it works OK.