### PR TITLE
Thumb-mode v7-A, v7-R and v8-R now at Tier 2 in nightly.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,13 +44,14 @@ jobs:
         run: |
           just build-tier2 ${{ matrix.target }}
 
-  # These targets need build-std
-  build-tier3:
+  build-tier2-nightly:
     runs-on: ubuntu-24.04
     needs: setup
     strategy:
       matrix:
         target:
+          # These targets made Tier 2 on 2026-06-04
+          # They'll move to build-tier2 once they reach stable
           - thumbv7r-none-eabi
           - thumbv7r-none-eabihf
           - thumbv7a-none-eabi
@@ -63,12 +64,12 @@ jobs:
         uses: taiki-e/install-action@just
       - name: Install Rust
         run: |
-          rustup install stable
-          rustup default stable
-          rustup component add rust-src
+          rustup install nightly-2026-06-04
+          rustup default nightly-2026-06-04
+          rustup target add ${{ matrix.target }}
       - name: Build
         run: |
-          just build-tier3 ${{ matrix.target }}
+          just build-tier2 ${{ matrix.target }}
 
   # These targets need build-std, and have no atomics so we have to skip
   # the 'critical-section-multi-core' feature
@@ -119,7 +120,7 @@ jobs:
   # Gather all the above build jobs together for the purposes of getting an overall pass-fail
   build-all:
     runs-on: ubuntu-24.04
-    needs: [build-tier2, build-tier3-no-atomics, build-tier3, build-arm-targets]
+    needs: [build-tier2, build-tier3-no-atomics, build-tier2-nightly, build-arm-targets]
     steps:
       - run: /bin/true
 

--- a/examples/mps3-an536-el2/rust-toolchain.toml
+++ b/examples/mps3-an536-el2/rust-toolchain.toml
@@ -1,6 +1,7 @@
 [toolchain]
-channel = "stable"
+channel = "nightly-2026-06-04"
 targets = [
 	"armv8r-none-eabihf",
+	"thumbv8r-none-eabihf",
 ]
 components = ["rust-src", "clippy", "rustfmt"]

--- a/examples/mps3-an536-smp/rust-toolchain.toml
+++ b/examples/mps3-an536-smp/rust-toolchain.toml
@@ -1,6 +1,7 @@
 [toolchain]
-channel = "stable"
+channel = "nightly-2026-06-04"
 targets = [
 	"armv8r-none-eabihf",
+	"thumbv8r-none-eabihf",
 ]
 components = ["rust-src", "clippy", "rustfmt"]

--- a/examples/mps3-an536/rust-toolchain.toml
+++ b/examples/mps3-an536/rust-toolchain.toml
@@ -1,6 +1,7 @@
 [toolchain]
-channel = "stable"
+channel = "nightly-2026-06-04"
 targets = [
 	"armv8r-none-eabihf",
+	"thumbv8r-none-eabihf",
 ]
 components = ["rust-src", "clippy", "rustfmt"]

--- a/examples/versatileab/rust-toolchain.toml
+++ b/examples/versatileab/rust-toolchain.toml
@@ -1,9 +1,13 @@
 [toolchain]
-channel = "stable"
+channel = "nightly-2026-06-04"
 targets = [
 	"armv7r-none-eabi",
 	"armv7r-none-eabihf",
 	"armv7a-none-eabi",
 	"armv7a-none-eabihf",
+	"thumbv7r-none-eabi",
+	"thumbv7r-none-eabihf",
+	"thumbv7a-none-eabi",
+	"thumbv7a-none-eabihf",
 ]
 components = ["rust-src", "clippy", "rustfmt"]

--- a/justfile
+++ b/justfile
@@ -40,15 +40,15 @@ build-all: \
 	(build-tier3-no-atomics "thumbv6-none-eabi") \
 	(build-tier3-no-atomics "armv6-none-eabihf") \
 	(build-tier2 "armv7r-none-eabi") \
-	(build-tier3 "thumbv7r-none-eabi") \
+	(build-tier2 "thumbv7r-none-eabi") \
 	(build-tier2 "armv7r-none-eabihf") \
-	(build-tier3 "thumbv7r-none-eabihf") \
+	(build-tier2 "thumbv7r-none-eabihf") \
 	(build-tier2 "armv7a-none-eabi") \
-	(build-tier3 "thumbv7a-none-eabi") \
+	(build-tier2 "thumbv7a-none-eabi") \
 	(build-tier2 "armv7a-none-eabihf") \
-	(build-tier3 "thumbv7a-none-eabihf") \
+	(build-tier2 "thumbv7a-none-eabihf") \
 	(build-tier2 "armv8r-none-eabihf") \
-	(build-tier3 "thumbv8r-none-eabihf") \
+	(build-tier2 "thumbv8r-none-eabihf") \
 
 # Build the arm-targets library
 build-arm-targets:
@@ -79,17 +79,17 @@ build-all-examples: \
 	(build-versatileab-tier3 "thumbv5te-none-eabi") \
 	(build-versatileab-tier3 "armv6-none-eabi") \
 	(build-versatileab-tier3 "armv6-none-eabihf") \
+	(build-versatileab-tier3 "thumbv6-none-eabi") \
 	(build-versatileab-tier2 "armv7r-none-eabi") \
-	(build-versatileab-tier3 "thumbv7r-none-eabi") \
+	(build-versatileab-tier2 "thumbv7r-none-eabi") \
 	(build-versatileab-tier2 "armv7r-none-eabihf") \
-	(build-versatileab-tier3 "thumbv7r-none-eabihf") \
+	(build-versatileab-tier2 "thumbv7r-none-eabihf") \
 	(build-versatileab-tier2 "armv7a-none-eabi") \
-	(build-versatileab-tier3 "thumbv7a-none-eabi") \
+	(build-versatileab-tier2 "thumbv7a-none-eabi") \
 	(build-versatileab-tier2 "armv7a-none-eabihf") \
-	(build-versatileab-tier3 "thumbv7a-none-eabihf") \
-	(build-mps3-tier2 "armv8r-none-eabihf") \
-	(build-mps3-tier3 "thumbv8r-none-eabihf") \
-	# (build-versatileab-tier3 "thumbv6-none-eabi") \
+	(build-versatileab-tier2 "thumbv7a-none-eabihf") \
+	(build-mps3-tier2        "armv8r-none-eabihf") \
+	(build-mps3-tier2        "thumbv8r-none-eabihf") \
 
 # Builds the Versatile AB examples, building core from source
 build-versatileab-tier3 target:


### PR DESCRIPTION
No more build-std for thumbv7* and thumbv8*.

Still needed for v4t, v5te and v6 though.

Closes #172.
