### PR TITLE
fix TEX in MemAttrBits for WriteBackWriteAlloc

### DIFF
--- a/aarch32-cpu/src/pmsav7.rs
+++ b/aarch32-cpu/src/pmsav7.rs
@@ -326,7 +326,7 @@ impl MemAttr {
                 s: *shareable,
             },
             MemAttr::WriteBackWriteAlloc { shareable } => MemAttrBits {
-                tex: u3::from_u8(0b000),
+                tex: u3::from_u8(0b001),
                 c: true,
                 b: true,
                 s: *shareable,


### PR DESCRIPTION
Fixes #181

Fix TEX bits in `MemAttrBits` for `MemAttr::WriteBackWriteAlloc` according to [B5.3.1: C, B, and TEX[2:0] encodings](https://developer.arm.com/documentation/ddi0406/cb/System-Level-Architecture/Protected-Memory-System-Architecture--PMSA-/Memory-region-attributes/C--B--and-TEX-2-0--encodings?lang=en).