### PR TITLE
Better arm-targets flags

### DIFF
--- a/aarch32-cpu/src/lib.rs
+++ b/aarch32-cpu/src/lib.rs
@@ -10,21 +10,11 @@ pub mod cache;
 pub mod interrupt;
 pub mod register;
 
-#[cfg(any(
-    doc,
-    arm_architecture = "v7-a",
-    arm_architecture = "v7-r",
-    arm_architecture = "v8-r"
-))]
+#[cfg(any(doc, armv7_or_higher))]
 #[path = "asmv7.rs"]
 pub mod asm;
 
-#[cfg(not(any(
-    doc,
-    arm_architecture = "v7-a",
-    arm_architecture = "v7-r",
-    arm_architecture = "v8-r"
-)))]
+#[cfg(not(any(doc, armv7_or_higher)))]
 #[path = "asmv4.rs"]
 pub mod asm;
 

--- a/aarch32-cpu/src/register/cpsr.rs
+++ b/aarch32-cpu/src/register/cpsr.rs
@@ -74,14 +74,7 @@ impl Cpsr {
     /// On Armv4T and Armv5TE this will be an Arm function, even on the
     /// `thumb*` targets, as Thumb-1 cannot do an MRS.
     #[cfg_attr(not(feature = "check-asm"), inline)]
-    #[cfg_attr(
-        any(
-            arm_architecture = "v4t",
-            arm_architecture = "v5te",
-            arm_architecture = "v6"
-        ),
-        instruction_set(arm::a32)
-    )]
+    #[cfg_attr(armv6_or_lower, instruction_set(arm::a32))]
     pub fn read() -> Self {
         let r: u32;
 
@@ -111,14 +104,7 @@ impl Cpsr {
     /// On Armv4T and Armv5TE this will be an Arm function, even on the
     /// `thumb*` targets, as Thumb-1 cannot do an MSR.
     #[cfg_attr(not(feature = "check-asm"), inline)]
-    #[cfg_attr(
-        any(
-            arm_architecture = "v4t",
-            arm_architecture = "v5te",
-            arm_architecture = "v6"
-        ),
-        instruction_set(arm::a32)
-    )]
+    #[cfg_attr(armv6_or_lower, instruction_set(arm::a32))]
     pub unsafe fn write(_value: Self) {
         // Safety: This is risky, but we're in an unsafe function
         #[cfg(target_arch = "arm")]

--- a/aarch32-cpu/src/register/mod.rs
+++ b/aarch32-cpu/src/register/mod.rs
@@ -27,7 +27,7 @@ pub mod dccsw;
 pub mod dcimvac;
 pub mod dcisw;
 pub mod dfar;
-#[cfg(all(target_arch = "arm", not(arm_architecture = "v4t")))]
+#[cfg(armv5te_or_higher)]
 pub mod dfsr;
 pub mod dlr;
 pub mod dracr;
@@ -53,7 +53,7 @@ pub mod id_mmfr4;
 pub mod id_pfr0;
 pub mod id_pfr1;
 pub mod ifar;
-#[cfg(all(target_arch = "arm", not(arm_architecture = "v4t")))]
+#[cfg(armv5te_or_higher)]
 pub mod ifsr;
 pub mod imp;
 pub mod iracr;
@@ -131,7 +131,7 @@ pub use dccsw::Dccsw;
 pub use dcimvac::Dcimvac;
 pub use dcisw::Dcisw;
 pub use dfar::Dfar;
-#[cfg(all(target_arch = "arm", not(arm_architecture = "v4t")))]
+#[cfg(armv5te_or_higher)]
 pub use dfsr::Dfsr;
 pub use dlr::Dlr;
 pub use dracr::Dracr;
@@ -157,7 +157,7 @@ pub use id_mmfr4::IdMmfr4;
 pub use id_pfr0::IdPfr0;
 pub use id_pfr1::IdPfr1;
 pub use ifar::Ifar;
-#[cfg(all(target_arch = "arm", not(arm_architecture = "v4t")))]
+#[cfg(armv5te_or_higher)]
 pub use ifsr::Ifsr;
 pub use iracr::Iracr;
 pub use irbar::Irbar;
@@ -250,14 +250,7 @@ pub trait SysRegRead: SysReg {
     /// side-effects that can cause Undefined Behaviour, so this method
     /// is safe.
     #[cfg_attr(not(feature = "check-asm"), inline)]
-    #[cfg_attr(
-        any(
-            arm_architecture = "v4t",
-            arm_architecture = "v5te",
-            arm_architecture = "v6"
-        ),
-        instruction_set(arm::a32)
-    )]
+    #[cfg_attr(armv6_or_lower, instruction_set(arm::a32))]
     fn read_raw() -> u32 {
         let r: u32;
         #[cfg(target_arch = "arm")]
@@ -290,14 +283,7 @@ pub trait SysRegWrite: SysReg {
     /// You need to read the Architecture Reference Manual to verify that you are
     /// writing valid data here.
     #[cfg_attr(not(feature = "check-asm"), inline)]
-    #[cfg_attr(
-        any(
-            arm_architecture = "v4t",
-            arm_architecture = "v5te",
-            arm_architecture = "v6"
-        ),
-        instruction_set(arm::a32)
-    )]
+    #[cfg_attr(armv6_or_lower, instruction_set(arm::a32))]
     unsafe fn write_raw(_value: u32) {
         #[cfg(target_arch = "arm")]
         unsafe {

--- a/aarch32-rt/src/lib.rs
+++ b/aarch32-rt/src/lib.rs
@@ -531,35 +531,24 @@
 #[cfg(target_arch = "arm")]
 use aarch32_cpu::register::{cpsr::ProcessorMode, Cpsr};
 
-#[cfg(all(
-    any(arm_architecture = "v7-a", arm_architecture = "v8-r"),
-    not(feature = "el2-mode")
+#[cfg(any(
+    arm_architecture = "v7-a",
+    all(arm_architecture = "v8-r", not(feature = "el2-mode")),
 ))]
 use aarch32_cpu::register::Hactlr;
 
 pub use aarch32_rt_macros::{entry, exception, irq};
 
-#[cfg(all(target_arch = "arm", arm_architecture = "v8-r", feature = "el2-mode"))]
+#[cfg(all(arm_architecture = "v8-r", feature = "el2-mode"))]
 mod arch_v8_hyp;
 
 #[cfg(all(
-    target_arch = "arm",
-    any(
-        arm_architecture = "v7-a",
-        arm_architecture = "v7-r",
-        all(arm_architecture = "v8-r", not(feature = "el2-mode"))
-    ),
+    armv7_or_higher,
+    not(all(arm_architecture = "v8-r", feature = "el2-mode"))
 ))]
 mod arch_v7;
 
-#[cfg(all(
-    target_arch = "arm",
-    not(any(
-        arm_architecture = "v7-a",
-        arm_architecture = "v7-r",
-        arm_architecture = "v8-r"
-    ))
-))]
+#[cfg(armv6_or_lower)]
 mod arch_v4;
 
 pub mod sections;
@@ -767,15 +756,7 @@ core::arch::global_asm!(
 /// This is for ARMv7 and ARMv8 systems with an FPU
 ///
 /// It just disables Thumb Exceptions and turns on the FPU
-#[cfg(all(
-    target_arch = "arm",
-    any(
-        arm_architecture = "v7-a",
-        arm_architecture = "v7-r",
-        arm_architecture = "v8-r"
-    ),
-    any(target_abi = "eabihf", feature = "eabi-fpu")
-))]
+#[cfg(all(armv7_or_higher, any(target_abi = "eabihf", feature = "eabi-fpu")))]
 macro_rules! system_init {
     () => {
         r#"
@@ -797,15 +778,7 @@ macro_rules! system_init {
 /// This is for ARMv7 and ARMv8 systems without an FPU
 ///
 /// It just disables Thumb Exceptions
-#[cfg(all(
-    target_arch = "arm",
-    any(
-        arm_architecture = "v7-a",
-        arm_architecture = "v7-r",
-        arm_architecture = "v8-r"
-    ),
-    not(any(target_abi = "eabihf", feature = "eabi-fpu"))
-))]
+#[cfg(all(armv7_or_higher, not(any(target_abi = "eabihf", feature = "eabi-fpu"))))]
 macro_rules! system_init {
     () => {
         r#"
@@ -820,15 +793,7 @@ macro_rules! system_init {
 /// This is for ARMv6 and earlier systems with an FPU
 ///
 /// It enables the FPU
-#[cfg(all(
-    target_arch = "arm",
-    not(any(
-        arm_architecture = "v7-a",
-        arm_architecture = "v7-r",
-        arm_architecture = "v8-r"
-    )),
-    any(target_abi = "eabihf", feature = "eabi-fpu")
-))]
+#[cfg(all(armv6_or_lower, any(target_abi = "eabihf", feature = "eabi-fpu")))]
 macro_rules! system_init {
     () => {
         r#"
@@ -846,14 +811,7 @@ macro_rules! system_init {
 /// This is for ARMv6 and earlier systems without an FPU
 ///
 /// It does nothing
-#[cfg(all(
-    not(any(
-        arm_architecture = "v7-a",
-        arm_architecture = "v7-r",
-        arm_architecture = "v8-r"
-    )),
-    not(any(target_abi = "eabihf", feature = "eabi-fpu"))
-))]
+#[cfg(all(armv6_or_lower, not(any(target_abi = "eabihf", feature = "eabi-fpu"))))]
 macro_rules! system_init {
     () => {
         r#"
@@ -1007,13 +965,8 @@ core::arch::global_asm!(
     },
 );
 
-// Start-up code for CPUs that boot into EL1
-//
-// Go straight to our default routine
-#[cfg(all(
-    target_arch = "arm",
-    not(any(arm_architecture = "v7-a", arm_architecture = "v8-r"))
-))]
+// Start-up code for CPUs that always boot into EL1
+#[cfg(any(armv6_or_lower, arm_architecture = "v7-r",))]
 core::arch::global_asm!(
     r#"
     // Work around https://github.com/rust-lang/rust/issues/127269
@@ -1055,15 +1008,10 @@ core::arch::global_asm!(
     "#
 );
 
-// Start-up code for Armv8-R to switch to EL1.
-//
-// There's only one Armv8-R CPU (the Cortex-R52) and the FPU is mandatory, so we
-// always enable it.
-//
-// We boot into EL2, set up a stack pointer, and run `kmain` in EL1.
-#[cfg(all(
-    any(arm_architecture = "v7-a", arm_architecture = "v8-r"),
-    not(feature = "el2-mode")
+// Start-up code for CPUs that *might* boot into EL2 but that we want in EL1.
+#[cfg(any(
+    arm_architecture = "v7-a",
+    all(arm_architecture = "v8-r", not(feature = "el2-mode")),
 ))]
 core::arch::global_asm!(
     r#"
@@ -1158,9 +1106,6 @@ core::arch::global_asm!(
 
 // Start-up code for Armv8-R to stay in EL2.
 //
-// There's only one Armv8-R CPU (the Cortex-R52) and the FPU is mandatory, so we
-// always enable it.
-//
 // We boot into EL2, set up a HYP stack pointer, and run `kmain` in EL2.
 #[cfg(all(arm_architecture = "v8-r", feature = "el2-mode"))]
 core::arch::global_asm!(
@@ -1213,7 +1158,7 @@ core::arch::global_asm!(
 ///
 /// Only required on Armv4T and Armv5TE, because Armv6K onwards support atomics.
 #[unsafe(no_mangle)]
-#[cfg(any(arm_architecture = "v4t", arm_architecture = "v5te"))]
+#[cfg(armv5te_or_lower)]
 pub extern "C" fn __sync_synchronize() {
     // we don't have a barrier instruction - the linux kernel just uses an empty inline asm block
     // so we do the same.

--- a/arm-targets/CHANGELOG.md
+++ b/arm-targets/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- New `armvXXX_or_higher` and `armvXXX_or_lower` flags for Legacy/R/A architectures.
+
 ## [v0.4.2]
 
 ### Changed

--- a/arm-targets/README.md
+++ b/arm-targets/README.md
@@ -19,6 +19,12 @@ cargo:rustc-cfg=arm_architecture="v7-r"
 cargo:rustc-check-cfg=cfg(arm_architecture, values("v6-m", "v7-m", "v7e-m", "v8-m.base", "v8-m.main", "v7-r", "v8-r", "v7-a", "v8-a"))
 cargo:rustc-cfg=arm_isa="A32"
 cargo:rustc-check-cfg=cfg(arm_isa, values("A64", "A32", "T32"))
+cargo:rustc-check-cfg=cfg(arm_v4t_or_higher)
+cargo:rustc-check-cfg=cfg(arm_v5te_or_higher)
+cargo:rustc-check-cfg=cfg(arm_v6_or_higher)
+cargo:rustc-check-cfg=cfg(arm_v7_or_higher)
+cargo:rustc-check-cfg=cfg(arm_v7_or_lower)
+cargo:rustc-check-cfg=cfg(arm_v8_or_lower)
 ```
 
 This allows you to write Rust code in your firmware like:

--- a/arm-targets/src/lib.rs
+++ b/arm-targets/src/lib.rs
@@ -34,8 +34,19 @@
 //! ```console
 //! $ cargo install arm-targets
 //! $ arm-targets
+//! // These are the features this crate enables:
 //! cargo:rustc-check-cfg=cfg(arm_isa, values("a64", "a32", "t32"))
-//! cargo:rustc-check-cfg=cfg(arm_architecture, values("v4t", "v5te", "v6-m", "v7-m", "v7e-m", "v8-m.base", "v8-m.main", "v7-r", "v8-r", "v7-a", "v8-a"))
+//! cargo:rustc-check-cfg=cfg(armv4t_or_higher)
+//! cargo:rustc-check-cfg=cfg(armv5te_or_higher)
+//! cargo:rustc-check-cfg=cfg(armv6_or_higher)
+//! cargo:rustc-check-cfg=cfg(armv7_or_higher)
+//! cargo:rustc-check-cfg=cfg(armv8_or_higher)
+//! cargo:rustc-check-cfg=cfg(armv4t_or_lower)
+//! cargo:rustc-check-cfg=cfg(armv5te_or_lower)
+//! cargo:rustc-check-cfg=cfg(armv6_or_lower)
+//! cargo:rustc-check-cfg=cfg(armv7_or_lower)
+//! cargo:rustc-check-cfg=cfg(armv8_or_lower)
+//! cargo:rustc-check-cfg=cfg(arm_architecture, values("v4t", "v5te", "v6", "v6-m", "v7-m", "v7e-m", "v8-m.base", "v8-m.main", "v7-r", "v8-r", "v7-a", "v8-a"))
 //! cargo:rustc-check-cfg=cfg(arm_profile, values("a", "r", "m", "legacy"))
 //! cargo:rustc-check-cfg=cfg(arm_abi, values("eabi", "eabihf"))
 //! ```
@@ -99,7 +110,62 @@ impl TargetInfo {
 
         if let Some(arch) = self.arch() {
             println!(r#"cargo:rustc-cfg=arm_architecture="{}""#, arch);
+            match arch {
+                Arch::Armv4T => {
+                    println!(r#"cargo:rustc-cfg=armv4t_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv4t_or_lower"#);
+                    println!(r#"cargo:rustc-cfg=armv5te_or_lower"#);
+                    println!(r#"cargo:rustc-cfg=armv6_or_lower"#);
+                    println!(r#"cargo:rustc-cfg=armv7_or_lower"#);
+                    println!(r#"cargo:rustc-cfg=armv8_or_lower"#);
+                }
+                Arch::Armv5TE => {
+                    println!(r#"cargo:rustc-cfg=armv4t_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv5te_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv5te_or_lower"#);
+                    println!(r#"cargo:rustc-cfg=armv6_or_lower"#);
+                    println!(r#"cargo:rustc-cfg=armv7_or_lower"#);
+                    println!(r#"cargo:rustc-cfg=armv8_or_lower"#);
+                }
+                Arch::Armv6 | Arch::Armv6M => {
+                    println!(r#"cargo:rustc-cfg=armv4t_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv5te_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv6_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv6_or_lower"#);
+                    println!(r#"cargo:rustc-cfg=armv7_or_lower"#);
+                    println!(r#"cargo:rustc-cfg=armv8_or_lower"#);
+                }
+                Arch::Armv7R | Arch::Armv7A => {
+                    println!(r#"cargo:rustc-cfg=armv4t_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv5te_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv6_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv7_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv7_or_lower"#);
+                    println!(r#"cargo:rustc-cfg=armv8_or_lower"#);
+                }
+                Arch::Armv8R | Arch::Armv8A => {
+                    println!(r#"cargo:rustc-cfg=armv4t_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv5te_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv6_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv7_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv8_or_higher"#);
+                    println!(r#"cargo:rustc-cfg=armv8_or_lower"#);
+                }
+                Arch::Armv7M | Arch::Armv7EM | Arch::Armv8MBase | Arch::Armv8MMain => {
+                    // don't claim M-profile architectures are compatible with full Armv7 or similar
+                }
+            }
         }
+        println!(r#"cargo:rustc-check-cfg=cfg(armv4t_or_higher)"#);
+        println!(r#"cargo:rustc-check-cfg=cfg(armv5te_or_higher)"#);
+        println!(r#"cargo:rustc-check-cfg=cfg(armv6_or_higher)"#);
+        println!(r#"cargo:rustc-check-cfg=cfg(armv7_or_higher)"#);
+        println!(r#"cargo:rustc-check-cfg=cfg(armv8_or_higher)"#);
+        println!(r#"cargo:rustc-check-cfg=cfg(armv4t_or_lower)"#);
+        println!(r#"cargo:rustc-check-cfg=cfg(armv5te_or_lower)"#);
+        println!(r#"cargo:rustc-check-cfg=cfg(armv6_or_lower)"#);
+        println!(r#"cargo:rustc-check-cfg=cfg(armv7_or_lower)"#);
+        println!(r#"cargo:rustc-check-cfg=cfg(armv8_or_lower)"#);
         println!(
             r#"cargo:rustc-check-cfg=cfg(arm_architecture, values({}))"#,
             Arch::values()


### PR DESCRIPTION
Adds some new cfg flags to arm-targets, to say "This architecture, or older" or "This architecture, or higher"

Saves application writers from having to construct convoluted conditionals to say things like "v5te, or v6, or v7-a, or v7-r, or v8-r". How they can express that as `cfg(armv5te_or_higher)`.