### PR TITLE
Remove derive-mmio dependency

### DIFF
--- a/examples/versatileab/Cargo.toml
+++ b/examples/versatileab/Cargo.toml
@@ -19,7 +19,6 @@ aarch32-cpu = { path = "../../aarch32-cpu", features = ["critical-section-single
 aarch32-rt = { path = "../../aarch32-rt" }
 arbitrary-int = "2.1.1"
 c-code = { version = "0.1.0", path = "../c-code" }
-derive-mmio = "0.6.1"
 libm = "0.2.15"
 pl190-vic = "0.1.2"
 portable-atomic = { version = "1.11.1", features = ["critical-section"] }


### PR DESCRIPTION
derive-mmio isn't used directly any more

This is probably left over from when the examples had their own PL190 driver