### PR TITLE
Draft: Bump MSRV to 1.95

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          echo 'rust_versions=["stable", "1.83"]' >> "$GITHUB_OUTPUT"
+          echo 'rust_versions=["stable", "1.96"]' >> "$GITHUB_OUTPUT"
           echo 'stable_targets=["armv7a-none-eabi","armv7a-none-eabihf","armv7r-none-eabi","armv7r-none-eabihf","armv8r-none-eabihf"]' >> "$GITHUB_OUTPUT"
 
   # Build the workspace for a target architecture
@@ -26,9 +26,9 @@ jobs:
         rust: ${{ fromJSON(needs.setup.outputs.rust-versions) }}
         target: ${{ fromJSON(needs.setup.outputs.stable-targets) }}
         exclude:
-          - rust: 1.83
+          - rust: 1.96
             target: armv7a-none-eabihf
-          - rust: 1.83
+          - rust: 1.96
             target: armv8r-none-eabihf
     steps:
       - name: Checkout
@@ -133,9 +133,9 @@ jobs:
         rust: ${{ fromJSON(needs.setup.outputs.rust-versions) }}
         target: ${{ fromJSON(needs.setup.outputs.stable-targets) }}
         exclude:
-          - rust: 1.83
+          - rust: 1.96
             target: armv7a-none-eabihf
-          - rust: 1.83
+          - rust: 1.96
             target: armv8r-none-eabihf
     steps:
       - name: Checkout

--- a/aarch32-cpu/Cargo.toml
+++ b/aarch32-cpu/Cargo.toml
@@ -21,7 +21,7 @@ name = "aarch32-cpu"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/aarch32.git"
 homepage = "https://github.com/rust-embedded/aarch32"
-rust-version = "1.83"
+rust-version = "1.96"
 version = "0.3.0"
 
 [dependencies]

--- a/aarch32-cpu/README.md
+++ b/aarch32-cpu/README.md
@@ -29,7 +29,7 @@ If you need a driver for the Arm Generic Interrupt Controller, see
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.83.0 and up, as recorded
+This crate is guaranteed to compile on stable Rust 1.96.0 and up, as recorded
 by the `package.rust-version` property in `Cargo.toml`.
 
 Increasing the MSRV is not considered a breaking change and may occur in a

--- a/aarch32-rt-macros/Cargo.toml
+++ b/aarch32-rt-macros/Cargo.toml
@@ -11,7 +11,7 @@ name = "aarch32-rt-macros"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/aarch32.git"
 homepage = "https://github.com/rust-embedded/aarch32"
-rust-version = "1.83"
+rust-version = "1.96"
 version = "0.3.0"
 
 [lib]

--- a/aarch32-rt-macros/README.md
+++ b/aarch32-rt-macros/README.md
@@ -6,7 +6,7 @@ This crate contains proc-macros that are re-exported through the `aarch32-rt` cr
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.83.0 and up, as recorded
+This crate is guaranteed to compile on stable Rust 1.96.0 and up, as recorded
 by the `package.rust-version` property in `Cargo.toml`.
 
 Increasing the MSRV is not considered a breaking change and may occur in a

--- a/aarch32-rt/Cargo.toml
+++ b/aarch32-rt/Cargo.toml
@@ -20,7 +20,7 @@ license = "MIT OR Apache-2.0"
 name = "aarch32-rt"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/aarch32.git"
-rust-version = "1.83"
+rust-version = "1.96"
 version = "0.3.0"
 
 [dependencies]

--- a/aarch32-rt/README.md
+++ b/aarch32-rt/README.md
@@ -22,7 +22,7 @@ uses different instructions for reading/writing system registers.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.83.0 and up, as recorded
+This crate is guaranteed to compile on stable Rust 1.96.0 and up, as recorded
 by the `package.rust-version` property in `Cargo.toml`.
 
 Increasing the MSRV is not considered a breaking change and may occur in a

--- a/arm-targets/Cargo.toml
+++ b/arm-targets/Cargo.toml
@@ -11,7 +11,7 @@ name = "arm-targets"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/aarch32.git"
 homepage = "https://github.com/rust-embedded/aarch32"
-rust-version = "1.83"
+rust-version = "1.96"
 version = "0.4.2"
 
 [dependencies]

--- a/arm-targets/README.md
+++ b/arm-targets/README.md
@@ -35,7 +35,7 @@ This allows you to write Rust code in your firmware like:
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.83.0 and up, as recorded
+This crate is guaranteed to compile on stable Rust 1.96.0 and up, as recorded
 by the `package.rust-version` property in `Cargo.toml`.
 
 Increasing the MSRV is not considered a breaking change and may occur in a


### PR DESCRIPTION
Allows us to resolve https://github.com/rust-embedded/aarch32/issues/106

Leaving as a draft because I worry that 1.95 is a bit too new