### PR TITLE
Collapse save_fpu_context/restore_fpu_context into a single macro

### DIFF
--- a/aarch32-rt/src/arch_v4/abort.rs
+++ b/aarch32-rt/src/arch_v4/abort.rs
@@ -21,13 +21,13 @@ core::arch::global_asm!(
         sub     sp, r12                   // SP now aligned - only push 64-bit values from here
         push    {{ r0-r4, r12 }}          // push alignment amount, and preserved registers - can now use R0-R3 (R4 is just padding)
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mov     r0, lr                    // Pass the faulting instruction address to the handler.
         bl      _data_abort_handler       // call C handler
         mov     lr, r0                    // if we get back here, assume they returned a new LR in r0
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r4, r12 }}          // restore preserved registers, dummy value, and alignment amount
         add     sp, r12                   // restore SP alignment using R12
@@ -61,13 +61,13 @@ core::arch::global_asm!(
         sub     sp, r12                   // SP now aligned - only push 64-bit values from here
         push    {{ r0-r4, r12 }}          // push alignment amount, and preserved registers - can now use R0-R3 (R4 is just padding)
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mov     r0, lr                    // Pass the faulting instruction address to the handler.
         bl      _prefetch_abort_handler   // call C handler
         mov     lr, r0                    // if we get back here, assume they returned a new LR in r0
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r4, r12 }}          // restore preserved registers, dummy value, and alignment amount
         add     sp, r12                   // restore SP alignment using R12

--- a/aarch32-rt/src/arch_v4/interrupt.rs
+++ b/aarch32-rt/src/arch_v4/interrupt.rs
@@ -40,11 +40,11 @@ core::arch::global_asm!(
         sub     sp, lr                    // SP now aligned - only push 64-bit values from here (6)
         push    {{ r0-r3, r12, lr }}      // push alignment amount (in LR) and preserved registers (7)
      "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         bl      _irq_handler              // call C handler in the selected handler mode (they may choose to re-enable interrupts)
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r3, r12, lr }}      // restore alignment amount (in LR) and preserved registers to undo (7)
         add     sp, lr                    // restore SP alignment using LR to undo (6)

--- a/aarch32-rt/src/arch_v4/svc.rs
+++ b/aarch32-rt/src/arch_v4/svc.rs
@@ -22,7 +22,7 @@ core::arch::global_asm!(
         push    {{ r0-r6, r12 }}          // push alignment amount, and stacked SVC argument registers (must be even number of regs for alignment)
         mov     r12, sp                   // save SP for integer frame
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mrs     r0, spsr                  // Load processor status that was banked on entry
         tst     r0, {t_bit}               // SVC occurred from Thumb state?
@@ -37,7 +37,7 @@ core::arch::global_asm!(
         bl      _svc_handler
         mov     lr, r0                    // move r0 out of the way - restore_fpu_context will trash it
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r6, r12 }}          // restore stacked registers and alignment amount
         mov     r0, lr                    // replace R0 with return value from _svc_handler

--- a/aarch32-rt/src/arch_v4/undefined.rs
+++ b/aarch32-rt/src/arch_v4/undefined.rs
@@ -27,13 +27,13 @@ core::arch::global_asm!(
         sub     sp, r12                   // SP now aligned - only push 64-bit values from here
         push    {{ r0-r4, r12 }}          // push alignment amount, and preserved registers - can now use R0-R3 (R4 is just padding)
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mov     r0, lr                    // Pass the faulting instruction address to the handler.
         bl      _undefined_handler        // call C handler
         mov     lr, r0                    // if we get back here, assume they returned a new LR in r0
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r4, r12 }}          // restore preserved registers, dummy value, and alignment amount
         add     sp, r12                   // restore SP alignment using R12

--- a/aarch32-rt/src/arch_v7/abort.rs
+++ b/aarch32-rt/src/arch_v7/abort.rs
@@ -21,13 +21,13 @@ core::arch::global_asm!(
         sub     sp, r12                   // SP now aligned - only push 64-bit values from here
         push    {{ r0-r4, r12 }}          // push alignment amount, and preserved registers - can now use R0-R3 (R4 is just padding)
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mov     r0, lr                    // Pass the faulting instruction address to the handler.
         bl      _data_abort_handler       // call C handler
         mov     lr, r0                    // if we get back here, assume they returned a new LR in r0
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r4, r12 }}          // restore preserved registers, dummy value, and alignment amount
         add     sp, r12                   // restore SP alignment using R12
@@ -60,13 +60,13 @@ core::arch::global_asm!(
         sub     sp, r12                   // SP now aligned - only push 64-bit values from here
         push    {{ r0-r4, r12 }}          // push alignment amount, and preserved registers - can now use R0-R3 (R4 is just padding)
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mov     r0, lr                    // Pass the faulting instruction address to the handler.
         bl      _prefetch_abort_handler   // call C handler
         mov     lr, r0                    // if we get back here, assume they returned a new LR in r0
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r4, r12 }}          // restore preserved registers, dummy value, and alignment amount
         add     sp, r12                   // restore SP alignment using R12

--- a/aarch32-rt/src/arch_v7/hvc.rs
+++ b/aarch32-rt/src/arch_v7/hvc.rs
@@ -19,14 +19,14 @@ core::arch::global_asm!(
         push    {{ r0-r5 }}               // push frame to stack
         mov     r12, sp                   // r12 = pointer to Frame
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mrc     p15, 4, r0, c5, c2, 0     // r0 = HSR value
         mov     r1, r12                   // r1 = frame pointer
         bl      _hvc_handler
         mov     r12, r0
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r5 }}               // restore frame
         mov     r0, r12                   // replace return value

--- a/aarch32-rt/src/arch_v7/interrupt.rs
+++ b/aarch32-rt/src/arch_v7/interrupt.rs
@@ -40,11 +40,11 @@ core::arch::global_asm!(
         sub     sp, lr                    // SP now aligned - only push 64-bit values from here (4)
         push    {{ r0-r3, r12, lr }}      // push alignment amount (in LR) and preserved registers (5)
      "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         bl      _irq_handler              // call C handler (they may choose to re-enable interrupts)
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r3, r12, lr }}      // restore alignment amount (in LR) and preserved registers to undo (5)
         add     sp, lr                    // restore SP alignment using LR to undo (4)

--- a/aarch32-rt/src/arch_v7/svc.rs
+++ b/aarch32-rt/src/arch_v7/svc.rs
@@ -21,7 +21,7 @@ core::arch::global_asm!(
         push    {{ r0-r6, r12 }}          // push alignment amount, and stacked SVC argument registers (must be even number of regs for alignment)
         mov     r12, sp                   // save SP for integer frame
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mrs     r0, spsr                  // Load processor status that was banked on entry
         tst     r0, {t_bit}               // SVC occurred from Thumb state?
@@ -32,7 +32,7 @@ core::arch::global_asm!(
         bl      _svc_handler
         mov     lr, r0                    // move r0 out of the way - restore_fpu_context will trash it
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r6, r12 }}          // restore stacked registers and alignment amount
         mov     r0, lr                    // replace R0 with return value from _svc_handler

--- a/aarch32-rt/src/arch_v7/undefined.rs
+++ b/aarch32-rt/src/arch_v7/undefined.rs
@@ -27,13 +27,13 @@ core::arch::global_asm!(
         sub     sp, r12                   // SP now aligned - only push 64-bit values from here
         push    {{ r0-r4, r12 }}          // push alignment amount, and preserved registers - can now use R0-R3 (R4 is just padding)
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mov     r0, lr                    // Pass the faulting instruction address to the handler.
         bl      _undefined_handler        // call C handler
         mov     lr, r0                    // if we get back here, assume they returned a new LR in r0
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r4, r12 }}          // restore preserved registers, dummy value, and alignment amount
         add     sp, r12                   // restore SP alignment using R12

--- a/aarch32-rt/src/arch_v8_hyp/abort.rs
+++ b/aarch32-rt/src/arch_v8_hyp/abort.rs
@@ -21,13 +21,13 @@ core::arch::global_asm!(
         sub     sp, r12                   // SP now aligned - only push 64-bit values from here
         push    {{ r0-r2, r12 }}          // save ELR, SPSR, padding and alignment amount
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mrs     r0, elr_hyp               // Pass the faulting instruction address to the handler.
         bl      _data_abort_handler       // call C handler
         msr     elr_hyp, r0               // if we get back here, assume they returned a new LR in r0
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r2, r12 }}          // restore ELR, SPSR, padding and alignment amount
         add     sp, r12                   // restore SP alignment
@@ -59,13 +59,13 @@ core::arch::global_asm!(
         sub     sp, r12                   // SP now aligned - only push 64-bit values from here
         push    {{ r0-r2, r12 }}          // save ELR, SPSR, padding and alignment amount
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mrs     r0, elr_hyp               // Pass the faulting instruction address to the handler.
         bl      _prefetch_abort_handler   // call C handler
         msr     elr_hyp, r0               // if we get back here, assume they returned a new LR in r0
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r2, r12 }}          // restore ELR, SPSR, padding and alignment amount
         add     sp, r12                   // restore SP alignment

--- a/aarch32-rt/src/arch_v8_hyp/hvc.rs
+++ b/aarch32-rt/src/arch_v8_hyp/hvc.rs
@@ -24,14 +24,14 @@ core::arch::global_asm!(
         push    {{ r0-r6, r12 }}          // push frame and alignment amount to stack
         mov     r12, sp                   // r12 = pointer to Frame
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mrc     p15, 4, r0, c5, c2, 0     // r0 = HSR value
         mov     r1, r12                   // r1 = frame pointer
         bl      _hvc_handler
         mov     lr, r0                    // copy return value into LR, because we're about to use r0 in the FPU restore
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r6, r12 }}          // restore frame and alignment
         mov     r0, lr                    // copy return value from lr back to r0, overwriting saved r0

--- a/aarch32-rt/src/arch_v8_hyp/interrupt.rs
+++ b/aarch32-rt/src/arch_v8_hyp/interrupt.rs
@@ -22,11 +22,11 @@ core::arch::global_asm!(
         sub     sp, r12                   // SP now aligned - only push 64-bit values from here (4)
         push    {{ r0-r2, r12 }}          // save ELR, SPSR, padding and alignment amount (5)
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         bl      _irq_handler              // call C handler (they may choose to re-enable interrupts)
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r2, r12 }}          // restore ELR, SPSR, padding and alignment amount to undo (5)
         add     sp, r12                   // restore SP alignment to undo (4)

--- a/aarch32-rt/src/arch_v8_hyp/svc.rs
+++ b/aarch32-rt/src/arch_v8_hyp/svc.rs
@@ -30,14 +30,14 @@ core::arch::global_asm!(
         push    {{ r0-r6, r12 }}          // push frame and alignment amount to stack
         mov     r12, sp                   // r12 = pointer to Frame
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mrc     p15, 4, r0, c5, c2, 0     // r0 = HSR value
         mov     r1, r12                   // r1 = frame pointer
         bl      _hvc_handler
         mov     lr, r0                    // copy return value into LR, because we're about to use r0 in the FPU restore
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r6, r12 }}          // restore frame and alignment
         mov     r0, lr                    // copy return value from lr back to r0, overwriting saved r0

--- a/aarch32-rt/src/arch_v8_hyp/undefined.rs
+++ b/aarch32-rt/src/arch_v8_hyp/undefined.rs
@@ -23,13 +23,13 @@ core::arch::global_asm!(
         sub     sp, r12                   // SP now aligned - only push 64-bit values from here
         push    {{ r0-r2, r12 }}          // save ELR, SPSR, padding and alignment amount
     "#,
-    crate::save_fpu_context!(),
+    crate::fpu_context!("save"),
     r#"
         mrs     r0, elr_hyp               // Pass the faulting instruction address to the handler.
         bl      _undefined_handler        // call C handler
         msr     elr_hyp, r0               // if we get back here, assume they returned a new LR in r0
     "#,
-    crate::restore_fpu_context!(),
+    crate::fpu_context!("restore"),
     r#"
         pop     {{ r0-r2, r12 }}          // restore ELR, SPSR, padding and alignment amount
         add     sp, r12                   // restore SP alignment

--- a/aarch32-rt/src/lib.rs
+++ b/aarch32-rt/src/lib.rs
@@ -600,38 +600,24 @@ pub struct Frame {
 // Macros
 // *****************************************************************************
 
-/// This macro expands to code for saving FPU context on entry to an exception
-/// handler. It pushes a multiple of eight bytes to preserve AAPCS alignment.
-/// It may damage R0-R3.
+/// This macro expands to nothing.
 ///
-/// It should match `restore_fpu_context!`
-///
-/// On entry to this block, we assume that we are in exception context.
+/// It's a placeholder for the FPU saving/restoring routine, used on
+/// targets without FPU support.
 #[cfg(not(any(target_abi = "eabihf", feature = "eabi-fpu")))]
 #[macro_export]
-macro_rules! save_fpu_context {
-    () => {
+macro_rules! fpu_context {
+    ("save") => {
+        ""
+    };
+    ("restore") => {
         ""
     };
 }
 
-/// This macro expands to code for restoring context on exit from an exception
-/// handler.
-///
-/// It should match `save_fpu_context!`.
-#[cfg(not(any(target_abi = "eabihf", feature = "eabi-fpu")))]
-#[macro_export]
-macro_rules! restore_fpu_context {
-    () => {
-        ""
-    };
-}
-
-/// This macro expands to code for saving FPU context on entry to an exception
+/// This macro expands to code for saving/restoring FPU context in an exception
 /// handler. It pushes a multiple of eight bytes to preserve AAPCS alignment.
 /// It may damage R0-R3.
-///
-/// It should match `restore_fpu_context!`
 ///
 /// On entry to this block, we assume that we are in exception context.
 ///
@@ -647,32 +633,19 @@ macro_rules! restore_fpu_context {
     not(feature = "fpu-d32")
 ))]
 #[macro_export]
-macro_rules! save_fpu_context {
-    () => {
+macro_rules! fpu_context {
+    // save all D16 FPU context, except D8-D15
+    ("save") => {
         r#"
-        // save all D16 FPU context, except D8-D15
         vpush   {{ d0-d7 }}
         vmrs    r0, FPSCR
         vmrs    r1, FPEXC
         push    {{ r0-r1 }}
         "#
     };
-}
-
-/// This macro expands to code for restoring context on exit from an exception
-/// handler. It restores FPU state, assuming 16 DP registers (a 'D16' or
-/// 'D16SP' FPU configuration).
-///
-/// It should match `save_fpu_context!`.
-#[cfg(all(
-    any(target_abi = "eabihf", feature = "eabi-fpu"),
-    not(feature = "fpu-d32")
-))]
-#[macro_export]
-macro_rules! restore_fpu_context {
-    () => {
+    // restore all D16 FPU context, except D8-D15
+    ("restore") => {
         r#"
-        // restore all D16 FPU context, except D8-D15
         pop     {{ r0-r1 }}
         vmsr    FPEXC, r1
         vmsr    FPSCR, r0
@@ -681,26 +654,24 @@ macro_rules! restore_fpu_context {
     };
 }
 
-/// This macro expands to code for saving FPU context on entry to an exception
-/// handler. It pushes a multiple of eight bytes to preserve AAPCS alignment.
-/// It may damage R0-R3.
-///
-/// It should match `restore_fpu_context!`
+/// This macro expands to code for saving/restoring FPU context in an exception
+/// handler. It pushes a multiple of eight bytes to preserve AAPCS alignment. It
+/// may damage R0-R3.
 ///
 /// On entry to this block, we assume that we are in exception context.
 ///
 /// This version saves FPU state assuming 32 DP registers (a 'D32' FPU
 /// configuration).
 ///
-/// EABI specifies D8-D15 as callee-save, and so we don't
-/// preserve them because any C function we call to handle the exception will
-/// preserve/restore them itself as required.
+/// EABI specifies D8-D15 as callee-save, and so we don't preserve them because
+/// any C function we call to handle the exception will preserve/restore them
+/// itself as required.
 #[cfg(all(any(target_abi = "eabihf", feature = "eabi-fpu"), feature = "fpu-d32"))]
 #[macro_export]
-macro_rules! save_fpu_context {
-    () => {
+macro_rules! fpu_context {
+    // save all D32 FPU context, except D8-D15
+    ("save") => {
         r#"
-        // save all D32 FPU context, except D8-D15
         vpush   {{ d0-d7 }}
         vpush   {{ d16-d31 }}
         vmrs    r0, FPSCR
@@ -708,19 +679,9 @@ macro_rules! save_fpu_context {
         push    {{ r0-r1 }}
         "#
     };
-}
-
-/// This macro expands to code for restoring context on exit from an exception
-/// handler. It restores FPU state, assuming 32 DP registers (a 'D32' FPU
-/// configuration).
-///
-/// It should match `save_fpu_context!`.
-#[cfg(all(any(target_abi = "eabihf", feature = "eabi-fpu"), feature = "fpu-d32"))]
-#[macro_export]
-macro_rules! restore_fpu_context {
-    () => {
+    // restore all D32 FPU context, except D8-D15
+    ("restore") => {
         r#"
-        // restore all D32 FPU context, except D8-D15
         pop     {{ r0-r1 }}
         vmsr    FPEXC, r1
         vmsr    FPSCR, r0


### PR DESCRIPTION
Instead of having two separate save/restore macros for FPU registers, which have to match, use one macro with an argument to indicate if it's saving or restoring.

This saves a bunch of repeated commentary where the macros are defined.