### PR TITLE
Add Xilinx Zynq-A9 example.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ exclude = [
   "examples/mps3-an536-smp",
   "examples/mps3-an536-el2",
   "examples/c-code",
+  "examples/xilinx-zynq-a9",
 ]
 members = [
   "aarch32-cpu",

--- a/examples/xilinx-zynq-a9/.cargo/config.toml
+++ b/examples/xilinx-zynq-a9/.cargo/config.toml
@@ -1,0 +1,14 @@
+[target.armv7a-none-eabihf]
+runner = "qemu-system-arm -machine xilinx-zynq-a9 -cpu cortex-a9 -semihosting -nographic -audio none -kernel"
+
+[target.thumbv7a-none-eabihf]
+runner = "qemu-system-arm -machine xilinx-zynq-a9 -cpu cortex-a9 -semihosting -nographic -audio none -kernel"
+
+[target.armv7a-none-eabi]
+runner = "qemu-system-arm -machine xilinx-zynq-a9 -cpu cortex-a9 -semihosting -nographic -audio none -kernel"
+
+[target.thumbv7a-none-eabi]
+runner = "qemu-system-arm -machine xilinx-zynq-a9 -cpu cortex-a9 -semihosting -nographic -audio none -kernel"
+
+[build]
+target = "armv7a-none-eabihf"

--- a/examples/xilinx-zynq-a9/Cargo.toml
+++ b/examples/xilinx-zynq-a9/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+authors = [
+	"Sriram Raghunathan <sriram@hcoop.net>",
+]
+default-run = "hello"
+description = "Examples for Xilinx-Zynq-A9 device (Arm Cortex-A9)"
+edition = "2024"
+homepage = "https://github.com/rust-embedded/aarch32"
+license = "MIT OR Apache-2.0"
+name = "xilinx-zynq-a9"
+publish = false
+readme = "README.md"
+repository = "https://github.com/rust-embedded/aarch32.git"
+version = "0.0.0"
+
+[dependencies]
+aarch32-cpu = { path = "../../aarch32-cpu", features = ["critical-section-multi-core"] }
+aarch32-rt = { path = "../../aarch32-rt" }
+arbitrary-int = "2.1.1"
+arm-gic = "0.8.1"
+c-code = { version = "0.1.0", path = "../c-code" }
+critical-section = "1.2.0"
+heapless = "0.9.1"
+libm = "0.2.15"
+portable-atomic = { version = "1.11.1", features = ["critical-section"] }
+semihosting = { version = "0.1.18", features = ["stdio"] }
+
+[build-dependencies]
+arm-targets = {version = "0.4.0", path = "../../arm-targets"}
+
+[features]
+eabi-fpu = ["aarch32-rt/eabi-fpu"]
+fpu-d32 = ["aarch32-rt/fpu-d32"]
+svc-stack-interrupt = ["aarch32-rt/svc-stack-interrupt"]

--- a/examples/xilinx-zynq-a9/README.md
+++ b/examples/xilinx-zynq-a9/README.md
@@ -1,0 +1,77 @@
+# Examples for the Xilinx Zynq-7000
+
+This package contains example binaries for the Xilinx Zynq-7000 SoC, featuring a
+dual-core Arm Cortex-A9 processor. This crate is tested on the following
+targets:
+
+- `armv7a-none-eabi` - ARMv7-A, soft-float, Arm mode
+- `armv7a-none-eabihf` - ARMv7-A, hard-float, Arm mode
+- `thumbv7a-none-eabi` - ARMv7-A, soft-float, Thumb mode
+- `thumbv7a-none-eabihf` - ARMv7-A, hard-float, Thumb mode
+
+The [`.cargo/config.toml`] in this folder will ensure the code runs on the
+appropriate QEMU configuration (the `xilinx-zynq-a9` machine with a `cortex-a9`
+CPU).
+
+This folder contains a [`rust-toolchain.toml`] which pins us to a specific
+release of nightly that is known to work.
+
+We have only tested this crate on `qemu-system-arm` emulating the Xilinx
+Zynq-7000, not the real thing.
+
+[`.cargo/config.toml`]: ./.cargo/config.toml
+[`rust-toolchain.toml`]: ./rust-toolchain.toml
+
+## Running
+
+Run these examples as follows:
+
+```console
+$ cargo run --bin hello
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.80s
+     Running `qemu-system-arm -machine xilinx-zynq-a9 -cpu cortex-a9 -semihosting -nographic -audio none -kernel target/armv7a-none-eabihf/debug/hello`
+Hello, this is semihosting! x = 1.000, y = 2.000
+PANIC: PanicInfo {
+    message: I am an example panic,
+    location: Location {
+        file: "src/bin/hello.rs",
+        line: 20,
+        column: 5,
+    },
+    can_unwind: true,
+    force_no_backtrace: false,
+}
+```
+
+## Debugging
+
+You can start a GDB server by adding `-- -s -S` to the end of the `cargo run`
+command, and then connect with GDB as follows:
+
+```console
+$ cargo run --bin hello -- -s -S
+# QEMU runs and hangs waiting for a connection. In another terminal run:
+$ arm-none-eabi-gdb target/armv7a-none-eabihf/debug/hello
+# Then, at the GDB prompt, connect to QEMU's GDB server:
+(gdb) target remote localhost:1234
+```
+
+## Minimum Supported Rust Version (MSRV)
+
+These examples are guaranteed to compile on the version of Rust given in the
+[`rust-toolchain.toml`] file. These examples are not version controlled and we
+may change the MSRV at any time.
+
+## Licence
+
+- Copyright (c) Ferrous Systems
+- Copyright (c) The Rust Embedded Devices Working Group developers
+
+Licensed under either [MIT](../LICENSE-MIT) or [Apache-2.0](../LICENSE-APACHE) at
+your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you shall be licensed as above, without any
+additional terms or conditions.

--- a/examples/xilinx-zynq-a9/build.rs
+++ b/examples/xilinx-zynq-a9/build.rs
@@ -1,4 +1,4 @@
-//! # Build script for the Xilinx-Zynq-A9 !example.
+//! # Build script for the Xilinx-Zynq-A9 example.
 //!
 //! This script only executes when using `cargo` to build the project.
 

--- a/examples/xilinx-zynq-a9/build.rs
+++ b/examples/xilinx-zynq-a9/build.rs
@@ -1,0 +1,24 @@
+//! # Build script for the Xilinx-Zynq-A9 !example.
+//!
+//! This script only executes when using `cargo` to build the project.
+
+use std::io::Write;
+
+fn main() {
+    arm_targets::process();
+    write("memory.x", include_bytes!("memory.x"));
+    // Use the aarch32-rt linker script
+    println!("cargo:rustc-link-arg=-Tlink.x");
+}
+
+fn write(file: &str, contents: &[u8]) {
+    // Put linker file in our output directory and ensure it's on the
+    // linker search path.
+    let out = &std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+    std::fs::File::create(out.join(file))
+        .unwrap()
+        .write_all(contents)
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+    println!("cargo:rerun-if-changed={}", file);
+}

--- a/examples/xilinx-zynq-a9/memory.x
+++ b/examples/xilinx-zynq-a9/memory.x
@@ -1,0 +1,26 @@
+/*
+Memory configuration for the Xilinx Zynq-7000 (Arm Cortex-A9), as emulated by
+the QEMU `xilinx-zynq-a9` machine.
+
+DDR SDRAM lives at 0x0000_0000. QEMU maps 128 MiB there by default (memory
+region `zynq.ext_ram`, 0x0000_0000 .. 0x07FF_FFFF).
+
+See https://github.com/qemu/qemu/blob/master/hw/arm/xilinx_zynq.c
+*/
+
+MEMORY {
+    DDR : ORIGIN = 0x00000000, LENGTH = 128M
+}
+
+REGION_ALIAS("VECTORS", DDR);
+REGION_ALIAS("CODE", DDR);
+REGION_ALIAS("DATA", DDR);
+REGION_ALIAS("STACKS", DDR);
+
+PROVIDE(_hyp_stack_size = 16K);
+PROVIDE(_und_stack_size = 16K);
+PROVIDE(_svc_stack_size = 16K);
+PROVIDE(_abt_stack_size = 16K);
+PROVIDE(_irq_stack_size = 64);
+PROVIDE(_fiq_stack_size = 64);
+PROVIDE(_sys_stack_size = 16K);

--- a/examples/xilinx-zynq-a9/reference/hello-armv7a-none-eabi.out
+++ b/examples/xilinx-zynq-a9/reference/hello-armv7a-none-eabi.out
@@ -1,0 +1,11 @@
+Hello, this is semihosting! x = 1.000, y = 2.000
+PANIC: PanicInfo {
+    message: I am an example panic,
+    location: Location {
+        file: "src/bin/hello.rs",
+        line: 20,
+        column: 5,
+    },
+    can_unwind: true,
+    force_no_backtrace: false,
+}

--- a/examples/xilinx-zynq-a9/reference/hello-armv7a-none-eabihf.out
+++ b/examples/xilinx-zynq-a9/reference/hello-armv7a-none-eabihf.out
@@ -1,0 +1,11 @@
+Hello, this is semihosting! x = 1.000, y = 2.000
+PANIC: PanicInfo {
+    message: I am an example panic,
+    location: Location {
+        file: "src/bin/hello.rs",
+        line: 20,
+        column: 5,
+    },
+    can_unwind: true,
+    force_no_backtrace: false,
+}

--- a/examples/xilinx-zynq-a9/reference/hello-thumbv7a-none-eabi.out
+++ b/examples/xilinx-zynq-a9/reference/hello-thumbv7a-none-eabi.out
@@ -1,0 +1,11 @@
+Hello, this is semihosting! x = 1.000, y = 2.000
+PANIC: PanicInfo {
+    message: I am an example panic,
+    location: Location {
+        file: "src/bin/hello.rs",
+        line: 20,
+        column: 5,
+    },
+    can_unwind: true,
+    force_no_backtrace: false,
+}

--- a/examples/xilinx-zynq-a9/reference/hello-thumbv7a-none-eabihf.out
+++ b/examples/xilinx-zynq-a9/reference/hello-thumbv7a-none-eabihf.out
@@ -1,0 +1,11 @@
+Hello, this is semihosting! x = 1.000, y = 2.000
+PANIC: PanicInfo {
+    message: I am an example panic,
+    location: Location {
+        file: "src/bin/hello.rs",
+        line: 20,
+        column: 5,
+    },
+    can_unwind: true,
+    force_no_backtrace: false,
+}

--- a/examples/xilinx-zynq-a9/rust-toolchain.toml
+++ b/examples/xilinx-zynq-a9/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2026-06-04"
+targets = []
+components = ["rust-src", "clippy", "rustfmt"]

--- a/examples/xilinx-zynq-a9/src/bin/hello.rs
+++ b/examples/xilinx-zynq-a9/src/bin/hello.rs
@@ -1,0 +1,21 @@
+//! Semihosting hello-world for the Xilinx Zynq-A9.
+
+#![no_std]
+#![no_main]
+
+use aarch32_rt::entry;
+use semihosting::println;
+use xilinx_zynq_a9 as _;
+
+/// The entry-point to the Rust application.
+///
+/// It is called by the start-up.
+#[entry]
+fn my_main() -> ! {
+    xilinx_zynq_a9::init();
+    let x = 1.0f64;
+    let y = x * 2.0;
+    println!("Hello, this is semihosting! x = {:0.3}, y = {:0.3}", x, y);
+    xilinx_zynq_a9::want_panic();
+    panic!("I am an example panic");
+}

--- a/examples/xilinx-zynq-a9/src/lib.rs
+++ b/examples/xilinx-zynq-a9/src/lib.rs
@@ -33,18 +33,10 @@ pub fn want_panic() {
 /// Init the hardware
 ///
 /// Includes enabling the MMU (if we have one)
+/// Supports  ARMv7-a only   #[cfg(arm_architecture = "v7-a")]
 pub fn init() {
-    #[cfg(arm_architecture = "v7-a")]
     mmu::set_mmu();
-
-    #[cfg(arm_architecture = "v7-a")]
     mmu::enable_mmu_and_cache();
-
-    #[cfg(arm_architecture = "v7-r")]
-    aarch32_cpu::register::Sctlr::modify(|s| {
-        // Enable Cache
-        s.set_c(true);
-    });
 }
 
 /// Exit from QEMU with code

--- a/examples/xilinx-zynq-a9/src/lib.rs
+++ b/examples/xilinx-zynq-a9/src/lib.rs
@@ -1,0 +1,97 @@
+#![no_std]
+
+#[cfg(arm_architecture="v7-a")]
+pub mod mmu; // Include the mmu
+
+static WANT_PANIC: portable_atomic::AtomicBool = portable_atomic::AtomicBool::new(false);
+
+/// Track if we're already in the exit routine.
+///
+/// Stops us doing infinite recursion if we panic whilst doing the stack reporting.
+static IN_EXIT: portable_atomic::AtomicBool = portable_atomic::AtomicBool::new(false);
+
+/// Called when the application raises an unrecoverable `panic!`.
+///
+/// Prints the panic to the console and then exits QEMU using a semihosting
+/// breakpoint.
+#[panic_handler]
+#[cfg(target_os = "none")]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    semihosting::println!("PANIC: {:#?}", info);
+    if WANT_PANIC.load(portable_atomic::Ordering::Relaxed) {
+        exit(0);
+    } else {
+        exit(1);
+    }
+}
+
+/// Set the panic function as no longer returning a failure code via semihosting
+pub fn want_panic() {
+    WANT_PANIC.store(true, portable_atomic::Ordering::Relaxed);
+}
+
+/// Init the hardware
+///
+/// Includes enabling the MMU (if we have one)
+pub fn init() {
+    #[cfg(arm_architecture = "v7-a")]
+    mmu::set_mmu();
+
+    #[cfg(arm_architecture = "v7-a")]
+    mmu::enable_mmu_and_cache();
+
+    #[cfg(arm_architecture = "v7-r")]
+    aarch32_cpu::register::Sctlr::modify(|s| {
+        // Enable Cache
+        s.set_c(true);
+    });
+}
+
+/// Exit from QEMU with code
+pub fn exit(code: i32) -> ! {
+    if !IN_EXIT.swap(true, portable_atomic::Ordering::Relaxed) {
+        stack_dump();
+    }
+    semihosting::process::exit(code)
+}
+
+/// Print stack using to semihosting output for each stack
+///
+/// Produces output like:
+///
+/// ```text
+/// Stack usage report:
+/// UND0 Stack =      0 used of  16384 bytes (000%) @ 0x1006bf80..0x1006ff80
+/// SVC0 Stack =      0 used of  16384 bytes (000%) @ 0x1006ff80..0x10073f80
+/// ABT0 Stack =      0 used of  16384 bytes (000%) @ 0x10073f80..0x10077f80
+/// HYP0 Stack =      0 used of  16384 bytes (000%) @ 0x10077f80..0x1007bf80
+/// IRQ0 Stack =      0 used of     64 bytes (000%) @ 0x1007bf80..0x1007bfc0
+/// FIQ0 Stack =      0 used of     64 bytes (000%) @ 0x1007bfc0..0x1007c000
+/// SYS0 Stack =   2416 used of  16384 bytes (014%) @ 0x1007c000..0x10080000
+/// ```
+fn stack_dump() {
+    use aarch32_cpu::stacks::stack_used_bytes;
+    use aarch32_rt::stacks::Stack;
+
+    semihosting::eprintln!("Stack usage report:");
+
+    unsafe {
+        for stack in Stack::iter() {
+            for core in (0..Stack::num_cores()).rev() {
+                let core_range = stack.range(core).unwrap();
+                let (total, used) = stack_used_bytes(core_range.clone());
+                let percent = used * 100 / total;
+                // Send to stderr, so it doesn't mix with expected output on stdout
+                semihosting::eprintln!(
+                    "{}{} Stack = {:6} used of {:6} bytes ({:03}%) @ {:08x?}",
+                    stack,
+                    core,
+                    used,
+                    total,
+                    percent,
+                    core_range
+                );
+            }
+        }
+    }
+}

--- a/examples/xilinx-zynq-a9/src/lib.rs
+++ b/examples/xilinx-zynq-a9/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
-#[cfg(arm_architecture="v7-a")]
-pub mod mmu; // Include the mmu
+pub mod mmu;
 
 static WANT_PANIC: portable_atomic::AtomicBool = portable_atomic::AtomicBool::new(false);
 
@@ -32,8 +31,7 @@ pub fn want_panic() {
 
 /// Init the hardware
 ///
-/// Includes enabling the MMU (if we have one)
-/// Supports  ARMv7-a only   #[cfg(arm_architecture = "v7-a")]
+/// Includes enabling the MMU.
 pub fn init() {
     mmu::set_mmu();
     mmu::enable_mmu_and_cache();

--- a/examples/xilinx-zynq-a9/src/mmu.rs
+++ b/examples/xilinx-zynq-a9/src/mmu.rs
@@ -1,0 +1,124 @@
+//! MMU Initialisation Code for the Xilinx Zynq-7000 (Arm Cortex-A9)
+//!
+//! Required when running with a VMSA processor, such as the Cortex-A9.
+//!
+//! Without MMU programming, all memory is strongly-ordered and that means
+//! unaligned loads will cause data aborts.
+//!
+//! ## Memory Map
+//!
+//! Addresses match the QEMU `xilinx-zynq-a9` machine.
+//!
+//! | Content           | Range                         | Attributes                  |
+//! |-------------------|-------------------------------|-----------------------------|
+//! | DDR SDRAM         | `0x0000_0000 .. 0x07FF_FFFF`  | Normal write-back cacheable |
+//! | Reserved          | `0x0800_0000 .. 0xDFFF_FFFF`  | Unassigned                  |
+//! | I/O Peripherals   | `0xE000_0000 .. 0xE0FF_FFFF`  | Device Memory               |
+//! | Reserved          | `0xE100_0000 .. 0xF7FF_FFFF`  | Unassigned                  |
+//! | System / MPCore   | `0xF800_0000 .. 0xF8FF_FFFF`  | Device Memory               |
+//! | Reserved          | `0xF900_0000 .. 0xFFFF_FFFF`  | Unassigned                  |
+//!
+//! The I/O Peripherals region holds the UARTs, GPIO, SPI, I2C etc. The System /
+//! MPCore region holds the SLCR, the Triple Timer Counters, and the Cortex-A9
+//! MPCore private peripherals (SCU, GIC, global timer, private timers and
+//! watchdog) at PERIPHBASE `0xF8F0_0000`.
+//!
+//! Note that this table is enough to run the examples, but it does not describe
+//! all the hardware either on the real board or emulated by QEMU.
+
+use aarch32_cpu::mmu::{
+    AccessPermissions, CachePolicy, L1Section, L1Table, MemoryRegionAttributes,
+    NUM_L1_PAGE_TABLE_ENTRIES, SectionAttributes,
+};
+use arbitrary_int::u4;
+
+/// Our MMU page table
+static MMU_L1_PAGE_TABLE: L1Table = make_mmu_table();
+
+const DDR_ATTRS: SectionAttributes = SectionAttributes {
+    non_global: false,
+    p_bit: false,
+    shareable: true,
+    access: AccessPermissions::FullAccess,
+    memory_attrs: MemoryRegionAttributes::CacheableMemory {
+        inner: CachePolicy::WriteBackWriteAlloc,
+        outer: CachePolicy::WriteBackWriteAlloc,
+    }
+    .as_raw(),
+    domain: u4::new(0b0),
+    execute_never: false,
+};
+
+const DEVICE_ATTRS: SectionAttributes = SectionAttributes {
+    non_global: false,
+    p_bit: false,
+    shareable: false,
+    access: AccessPermissions::FullAccess,
+    memory_attrs: MemoryRegionAttributes::ShareableDevice.as_raw(),
+    domain: u4::new(0b0),
+    execute_never: false,
+};
+
+/// The number of bytes in 1 MiB
+const ONE_MB: u32 = 1024 * 1024;
+
+const fn make_mmu_table() -> L1Table {
+    let mut temp: [L1Section; NUM_L1_PAGE_TABLE_ENTRIES] =
+        [L1Section::ZERO; NUM_L1_PAGE_TABLE_ENTRIES];
+    let mut page = 0;
+    // Map 128 MiB of DDR SDRAM @ 0x0000_0000
+    while page < 128 {
+        let section =
+            L1Section::new_with_addr_and_attrs(0x0000_0000 + (page * ONE_MB), DDR_ATTRS);
+        temp[0x000 + (page as usize)] = section;
+        page += 1;
+    }
+    // Map 16 MiB of I/O peripherals @ 0xE000_0000 (UARTs, GPIO, SPI, I2C, ...)
+    page = 0;
+    while page < 16 {
+        let section =
+            L1Section::new_with_addr_and_attrs(0xE000_0000 + (page * ONE_MB), DEVICE_ATTRS);
+        temp[0xE00 + (page as usize)] = section;
+        page += 1;
+    }
+    // Map 16 MiB of system / MPCore peripherals @ 0xF800_0000 (SLCR, timers,
+    // and the Cortex-A9 MPCore GIC/timers at PERIPHBASE 0xF8F0_0000)
+    page = 0;
+    while page < 16 {
+        let section =
+            L1Section::new_with_addr_and_attrs(0xF800_0000 + (page * ONE_MB), DEVICE_ATTRS);
+        temp[0xF80 + (page as usize)] = section;
+        page += 1;
+    }
+
+    L1Table {
+        entries: core::cell::UnsafeCell::new(temp),
+    }
+}
+
+/// Set the MMU base register to `MMU_L1_PAGE_TABLE`
+pub fn set_mmu() {
+    let ttbr0 = aarch32_cpu::register::Ttbr0::new_with_raw_value(0)
+        .with_address(core::ptr::addr_of!(MMU_L1_PAGE_TABLE) as usize)
+        .with_irgn(false)
+        .with_nos(false)
+        .with_rgn(aarch32_cpu::register::ttbr0::Region::WriteBackWriteAllocCacheable)
+        .with_s(true)
+        .with_c(true);
+    unsafe { aarch32_cpu::register::Ttbr0::write(ttbr0) }
+}
+
+/// Enable the MMU and the cache
+pub fn enable_mmu_and_cache() {
+    // Enable Manager access to Domain 0
+    aarch32_cpu::register::Dacr::modify(|d| {
+        d.set_d(0, aarch32_cpu::register::dacr::DomainAccess::Manager);
+    });
+    // This function contains the barrier we need to flush the pipeline
+    aarch32_cpu::register::Sctlr::modify(|s| {
+        // Enable Cache
+        s.set_c(true);
+        // Enable MMU
+        s.set_m(true);
+    });
+}

--- a/examples/xilinx-zynq-a9/src/mmu.rs
+++ b/examples/xilinx-zynq-a9/src/mmu.rs
@@ -68,8 +68,7 @@ const fn make_mmu_table() -> L1Table {
     let mut page = 0;
     // Map 128 MiB of DDR SDRAM @ 0x0000_0000
     while page < 128 {
-        let section =
-            L1Section::new_with_addr_and_attrs(0x0000_0000 + (page * ONE_MB), DDR_ATTRS);
+        let section = L1Section::new_with_addr_and_attrs(0x0000_0000 + (page * ONE_MB), DDR_ATTRS);
         temp[0x000 + (page as usize)] = section;
         page += 1;
     }

--- a/justfile
+++ b/justfile
@@ -307,8 +307,9 @@ test-qemu-v7a-zynq:
 	FAIL=0
 	./tests.sh examples/xilinx-zynq-a9 armv7a-none-eabi {{verbose}} --release || FAIL=1
 	./tests.sh examples/xilinx-zynq-a9 armv7a-none-eabihf {{verbose}} --release || FAIL=1
-        ./tests.sh examples/xilinx-zynq-a9 thumbv7a-none-eabi {{verbose}} --release || FAIL=1
-        if [ "${FAIL}" == "1" ]; then exit 1; fi
+	./tests.sh examples/xilinx-zynq-a9 thumbv7a-none-eabi {{verbose}} --release || FAIL=1
+	./tests.sh examples/xilinx-zynq-a9 thumbv7a-none-eabihf {{verbose}} --release || FAIL=1
+	if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 test-qemu-v7r:
 	#!/bin/bash

--- a/justfile
+++ b/justfile
@@ -30,6 +30,8 @@ clean:
 	rm -rf examples/mps3-an536/target-d32
 	cd examples/mps3-an536-smp && cargo clean
 	rm -rf examples/mps3-an536-smp/target-d32
+	cd examples/xilinx-zynq-a9 && cargo clean
+	rm -rf examples/xilinx-zynq-a9/target-d32
 
 # Builds our workspace for all targets
 build-all: \
@@ -92,6 +94,10 @@ build-all-examples: \
 	(build-versatileab-tier2 "thumbv7a-none-eabihf") \
 	(build-mps3-tier2        "armv8r-none-eabihf") \
 	(build-mps3-tier2        "thumbv8r-none-eabihf") \
+	(build-zynq-tier2        "armv7a-none-eabi") \
+	(build-zynq-tier2        "thumbv7a-none-eabi") \
+	(build-zynq-tier2        "armv7a-none-eabihf") \
+	(build-zynq-tier2        "thumbv7a-none-eabihf") \
 
 # Builds the Versatile AB examples, building core from source
 build-versatileab-tier3 target:
@@ -112,6 +118,14 @@ build-mps3-tier2 target:
 	cd examples/mps3-an536 && cargo build --target={{target}} {{verbose}}
 	cd examples/mps3-an536-smp && cargo build --target={{target}} {{verbose}}
 	cd examples/mps3-an536-el2 && cargo build --target={{target}} {{verbose}}
+
+# Builds the Xilinx Zynq-A9 examples, building core from source
+build-zynq-tier3 target:
+	cd examples/xilinx-zynq-a9 && cargo build --target={{target}} -Zbuild-std=core {{verbose}}
+
+# Builds the Xilinx Zynq-A9 examples, assuming core has been prebuilt
+build-zynq-tier2 target:
+	cd examples/xilinx-zynq-a9 && cargo build --target={{target}} {{verbose}}
 
 # Documents our workspace for all targets
 doc-all: \
@@ -166,6 +180,7 @@ fmt:
 	cd examples/mps3-an536 && cargo fmt {{verbose}}
 	cd examples/mps3-an536-smp && cargo fmt {{verbose}}
 	cd examples/mps3-an536-el2 && cargo fmt {{verbose}}
+	cd examples/xilinx-zynq-a9 && cargo fmt {{verbose}}
 
 # Checks all the code is formatted
 fmt-check:
@@ -178,6 +193,7 @@ fmt-check:
 	cd examples/mps3-an536 && cargo fmt --check {{verbose}}
 	cd examples/mps3-an536-smp && cargo fmt --check {{verbose}}
 	cd examples/mps3-an536-el2 && cargo fmt --check {{verbose}}
+	cd examples/xilinx-zynq-a9 && cargo fmt --check {{verbose}}
 
 # Checks all the cross-compiled workspace passes the clippy lints
 clippy-all: \
@@ -214,6 +230,7 @@ clippy-examples:
 	cd examples/mps3-an536 && cargo clippy --target=armv8r-none-eabihf {{verbose}}
 	cd examples/mps3-an536-smp && cargo clippy --target=armv8r-none-eabihf {{verbose}}
 	cd examples/mps3-an536-el2 && cargo clippy --target=armv8r-none-eabihf {{verbose}}
+	cd examples/xilinx-zynq-a9 && cargo clippy --target=armv7a-none-eabi {{verbose}}
 
 # Checks all the cross-compiled workspace passes the clippy lints
 clippy-tier3-no-atomics target:
@@ -243,7 +260,7 @@ test-cargo:
 	cd arm-targets && cargo test {{verbose}}
 
 # Run the integration tests in QEMU
-test-qemu: test-qemu-v4t test-qemu-v5te test-qemu-v6 test-qemu-v7a test-qemu-v7r test-qemu-v8r test-qemu-v8r-smp test-qemu-v8r-el2
+test-qemu: test-qemu-v4t test-qemu-v5te test-qemu-v6 test-qemu-v7a test-qemu-v7a-zynq test-qemu-v7r test-qemu-v8r test-qemu-v8r-smp test-qemu-v8r-el2
 
 test-qemu-v4t:
 	#!/bin/bash
@@ -287,6 +304,15 @@ test-qemu-v7a:
 	./tests.sh examples/versatileab thumbv7a-none-eabihf {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
 	RUSTFLAGS=-Ctarget-feature=+d32 ./tests.sh examples/versatileab armv7a-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
 	RUSTFLAGS=-Ctarget-feature=+d32 ./tests.sh examples/versatileab thumbv7a-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
+	if [ "${FAIL}" == "1" ]; then exit 1; fi
+
+test-qemu-v7a-zynq:
+	#!/bin/bash
+	FAIL=0
+	./tests.sh examples/xilinx-zynq-a9 armv7a-none-eabi {{verbose}} --release || FAIL=1
+	./tests.sh examples/xilinx-zynq-a9 thumbv7a-none-eabi -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/xilinx-zynq-a9 armv7a-none-eabihf {{verbose}} --release || FAIL=1
+	./tests.sh examples/xilinx-zynq-a9 thumbv7a-none-eabihf -Zbuild-std=core {{verbose}} --release || FAIL=1
 	if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 test-qemu-v7r:

--- a/justfile
+++ b/justfile
@@ -119,10 +119,6 @@ build-mps3-tier2 target:
 	cd examples/mps3-an536-smp && cargo build --target={{target}} {{verbose}}
 	cd examples/mps3-an536-el2 && cargo build --target={{target}} {{verbose}}
 
-# Builds the Xilinx Zynq-A9 examples, building core from source
-build-zynq-tier3 target:
-	cd examples/xilinx-zynq-a9 && cargo build --target={{target}} -Zbuild-std=core {{verbose}}
-
 # Builds the Xilinx Zynq-A9 examples, assuming core has been prebuilt
 build-zynq-tier2 target:
 	cd examples/xilinx-zynq-a9 && cargo build --target={{target}} {{verbose}}
@@ -310,10 +306,9 @@ test-qemu-v7a-zynq:
 	#!/bin/bash
 	FAIL=0
 	./tests.sh examples/xilinx-zynq-a9 armv7a-none-eabi {{verbose}} --release || FAIL=1
-	./tests.sh examples/xilinx-zynq-a9 thumbv7a-none-eabi -Zbuild-std=core {{verbose}} --release || FAIL=1
 	./tests.sh examples/xilinx-zynq-a9 armv7a-none-eabihf {{verbose}} --release || FAIL=1
-	./tests.sh examples/xilinx-zynq-a9 thumbv7a-none-eabihf -Zbuild-std=core {{verbose}} --release || FAIL=1
-	if [ "${FAIL}" == "1" ]; then exit 1; fi
+        ./tests.sh examples/xilinx-zynq-a9 thumbv7a-none-eabi {{verbose}} --release || FAIL=1
+        if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 test-qemu-v7r:
 	#!/bin/bash


### PR DESCRIPTION
The example follows the versatileab layout:

* `memory.x` : 128 MiB of DDR at 0x00, matching QEMU's default RAM region
* `src/mmu.rs` : L1 page table mapping DDR as normal cacheable memory.
* `src/bin/hello.rs`: semihosting hello-world

This patch is a preparatory work for the SMP based Xilin Zynq A9 which needs further components like the Gic, timers to be introduced.

Please refer to README.md for running instructions and references for the golden standard outputs