### PR TITLE
We don't need build-std for the thumbv7* and thumbv8* targets

### DIFF
--- a/justfile
+++ b/justfile
@@ -278,57 +278,57 @@ test-qemu-v7a:
 	#!/bin/bash
 	FAIL=0
 	./tests.sh examples/versatileab armv7a-none-eabi {{verbose}} --release || FAIL=1
-	./tests.sh examples/versatileab thumbv7a-none-eabi -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab thumbv7a-none-eabi {{verbose}} --release || FAIL=1
 	./tests.sh examples/versatileab armv7a-none-eabihf {{verbose}} --release || FAIL=1
-	./tests.sh examples/versatileab thumbv7a-none-eabihf -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab thumbv7a-none-eabihf {{verbose}} --release || FAIL=1
 	./tests.sh examples/versatileab armv7a-none-eabi {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
-	./tests.sh examples/versatileab thumbv7a-none-eabi -Zbuild-std=core {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
+	./tests.sh examples/versatileab thumbv7a-none-eabi {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
 	./tests.sh examples/versatileab armv7a-none-eabihf {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
-	./tests.sh examples/versatileab thumbv7a-none-eabihf -Zbuild-std=core {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
+	./tests.sh examples/versatileab thumbv7a-none-eabihf {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
 	RUSTFLAGS=-Ctarget-feature=+d32 ./tests.sh examples/versatileab armv7a-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
-	RUSTFLAGS=-Ctarget-feature=+d32 ./tests.sh examples/versatileab thumbv7a-none-eabihf -Zbuild-std=core --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
+	RUSTFLAGS=-Ctarget-feature=+d32 ./tests.sh examples/versatileab thumbv7a-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
 	if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 test-qemu-v7r:
 	#!/bin/bash
 	FAIL=0
 	./tests.sh examples/versatileab armv7r-none-eabi {{verbose}} --release || FAIL=1
-	./tests.sh examples/versatileab thumbv7r-none-eabi -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab thumbv7r-none-eabi {{verbose}} --release || FAIL=1
 	./tests.sh examples/versatileab armv7r-none-eabihf {{verbose}} --release || FAIL=1
-	./tests.sh examples/versatileab thumbv7r-none-eabihf -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/versatileab thumbv7r-none-eabihf {{verbose}} --release || FAIL=1
 	./tests.sh examples/versatileab armv7r-none-eabi {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
-	./tests.sh examples/versatileab thumbv7r-none-eabi -Zbuild-std=core {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
+	./tests.sh examples/versatileab thumbv7r-none-eabi {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
 	./tests.sh examples/versatileab armv7r-none-eabihf {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
-	./tests.sh examples/versatileab thumbv7r-none-eabihf -Zbuild-std=core {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
+	./tests.sh examples/versatileab thumbv7r-none-eabihf {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
 	if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 test-qemu-v8r:
 	#!/bin/bash
 	FAIL=0
 	./tests.sh examples/mps3-an536 armv8r-none-eabihf {{verbose}} --release || FAIL=1
-	./tests.sh examples/mps3-an536 thumbv8r-none-eabihf -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/mps3-an536 thumbv8r-none-eabihf {{verbose}} --release || FAIL=1
 	./tests.sh examples/mps3-an536 armv8r-none-eabihf {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
-	./tests.sh examples/mps3-an536 thumbv8r-none-eabihf -Zbuild-std=core {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
+	./tests.sh examples/mps3-an536 thumbv8r-none-eabihf {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
 	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536 armv8r-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
-	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536 thumbv8r-none-eabihf -Zbuild-std=core --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
+	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536 thumbv8r-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
 	if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 test-qemu-v8r-smp:
 	#!/bin/bash
 	FAIL=0
 	./tests.sh examples/mps3-an536-smp armv8r-none-eabihf {{verbose}} --release || FAIL=1
-	./tests.sh examples/mps3-an536-smp thumbv8r-none-eabihf -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/mps3-an536-smp thumbv8r-none-eabihf {{verbose}} --release || FAIL=1
 	./tests.sh examples/mps3-an536-smp armv8r-none-eabihf {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
-	./tests.sh examples/mps3-an536-smp thumbv8r-none-eabihf -Zbuild-std=core {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
+	./tests.sh examples/mps3-an536-smp thumbv8r-none-eabihf {{verbose}} --features=svc-stack-interrupt --release || FAIL=1
 	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536-smp armv8r-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
-	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536-smp thumbv8r-none-eabihf -Zbuild-std=core --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
+	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536-smp thumbv8r-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
 	if [ "${FAIL}" == "1" ]; then exit 1; fi
 
 test-qemu-v8r-el2:
 	#!/bin/bash
 	FAIL=0
 	./tests.sh examples/mps3-an536-el2 armv8r-none-eabihf {{verbose}} --release || FAIL=1
-	./tests.sh examples/mps3-an536-el2 thumbv8r-none-eabihf -Zbuild-std=core {{verbose}} --release || FAIL=1
+	./tests.sh examples/mps3-an536-el2 thumbv8r-none-eabihf {{verbose}} --release || FAIL=1
 	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536-el2 armv8r-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
-	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536-el2 thumbv8r-none-eabihf -Zbuild-std=core --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
+	RUSTFLAGS=-Ctarget-cpu=cortex-r52 ./tests.sh examples/mps3-an536-el2 thumbv8r-none-eabihf --features=fpu-d32 --target-dir=target-d32 {{verbose}} --release || FAIL=1
 	if [ "${FAIL}" == "1" ]; then exit 1; fi


### PR DESCRIPTION
libcore is available in rustup for our chosen nightly toolchain for `thumbv7a-none-eabi*`, `thumbv7r-none-eabi*` and `thumbv8r-none-eabihf`. So let's use it.

They were even in the rust-toolchain.toml file already :/