### PR TITLE
Prepare aarch32-rt 0.5 with SMP support

### DIFF
--- a/aarch32-rt-macros/CHANGELOG.md
+++ b/aarch32-rt-macros/CHANGELOG.md
@@ -10,6 +10,10 @@ As of *aarch32-rt-macros v0.1.0*, this project is released in lock-step with
 
 ## [Unreleased]
 
+## [aarch32-rt-macros v0.5.0]
+
+- No changes
+
 ## [aarch32-rt-macros v0.4.0]
 
 - Increased MSRV to 1.93
@@ -37,7 +41,8 @@ As of *aarch32-rt-macros v0.1.0*, this project is released in lock-step with
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/aarch32/compare/aarch32-rt-v0.4.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/aarch32/compare/aarch32-rt-v0.5.0...HEAD
+[aarch32-rt-macros v0.5.0]: https://github.com/rust-embedded/aarch32/compare/aarch32-rt-v0.4.0...aarch32-rt-v0.5.0
 [aarch32-rt-macros v0.4.0]: https://github.com/rust-embedded/aarch32/compare/aarch32-rt-v0.3.0...aarch32-rt-v0.4.0
 [aarch32-rt-macros v0.3.0]: https://github.com/rust-embedded/aarch32/compare/aarch32-rt-v0.2.0...aarch32-rt-v0.3.0
 [aarch32-rt-macros v0.2.0]: https://github.com/rust-embedded/aarch32/compare/aarch32-rt-v0.1.0...aarch32-rt-v0.2.0

--- a/aarch32-rt-macros/Cargo.toml
+++ b/aarch32-rt-macros/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/aarch32.git"
 homepage = "https://github.com/rust-embedded/aarch32"
 rust-version = "1.93"
-version = "0.4.0"
+version = "0.5.0"
 
 [lib]
 proc-macro = true

--- a/aarch32-rt/CHANGELOG.md
+++ b/aarch32-rt/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [aarch32-rt v0.5.0]
+
+### Added
+
+- Improved SMP support - you now only have to supply a
+  `_asm_secondary_core_park` function to park/release any secondary cores (such
+  cores enter a WFE loop by default)
+- New `fn _asm_stack_setup_preallocated(core_id: u32)` function exported
+- New `fn _asm_init_segments()` which initialises the `.data` and `.bss` segments
+- New `fn _asm_core_start()` which does some core set-up (enable FPU, wipe
+  registers, etc) then calls `kmain` or `kmain_secondary`
+- New internal (but exported) `_default_kmain_secondary` symbol
+- New internal (but exported) `_asm_default_secondary_core_park` symbol
+
+### Removed
+
+- Internal (but exported) `_stack_setup_preallocated` function
+- Internal (but exported) `_init_segments` function
+
 ## [aarch32-rt v0.4.0]
 
 ### Added
@@ -86,7 +105,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/aarch32/compare/aarch32-rt-v0.4.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/aarch32/compare/aarch32-rt-v0.5.0...HEAD
+[aarch32-rt v0.5.0]: https://github.com/rust-embedded/aarch32/compare/aarch32-rt-v0.4.0...aarch32-rt-v0.5.0
 [aarch32-rt v0.4.0]: https://github.com/rust-embedded/aarch32/compare/aarch32-rt-v0.3.0...aarch32-rt-v0.4.0
 [aarch32-rt v0.3.0]: https://github.com/rust-embedded/aarch32/compare/aarch32-rt-v0.2.0...aarch32-rt-v0.3.0
 [aarch32-rt v0.2.0]: https://github.com/rust-embedded/aarch32/compare/aarch32-rt-v0.1.0...aarch32-rt-v0.2.0

--- a/aarch32-rt/CHANGELOG.md
+++ b/aarch32-rt/CHANGELOG.md
@@ -11,20 +11,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Improved SMP support - you now only have to supply a
-  `_asm_secondary_core_park` function to park/release any secondary cores (such
-  cores enter a WFE loop by default)
-- New `fn _asm_stack_setup_preallocated(core_id: u32)` function exported
-- New `fn _asm_init_segments()` which initialises the `.data` and `.bss` segments
-- New `fn _asm_core_start()` which does some core set-up (enable FPU, wipe
-  registers, etc) then calls `kmain` or `kmain_secondary`
-- New internal (but exported) `_default_kmain_secondary` symbol
-- New internal (but exported) `_asm_default_secondary_core_park` symbol
+- Improved SMP support on ARMv7-A, ARMv7-R and ARMv8-R:
+  - you now only have to supply a `_asm_secondary_core_park` function to
+    park/release any secondary cores (such cores enter a WFE loop by default)
+- New exported symbol `_asm_core_start`
+- New exported symbol `_default_kmain_secondary`
+- New exported symbol `_asm_default_secondary_core_park`
 
-### Removed
+### Changed
 
-- Internal (but exported) `_stack_setup_preallocated` function
-- Internal (but exported) `_init_segments` function
+- Renamed exported symbol `_stack_setup_preallocated` to `_asm_stack_setup_preallocated`
+- Renamed exported symbol `_init_segments` to `_asm_init_segments`
 
 ## [aarch32-rt v0.4.0]
 

--- a/aarch32-rt/Cargo.toml
+++ b/aarch32-rt/Cargo.toml
@@ -21,11 +21,11 @@ name = "aarch32-rt"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/aarch32.git"
 rust-version = "1.93"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 aarch32-cpu = { version = "0.4.0", path = "../aarch32-cpu" }
-aarch32-rt-macros = { path = "../aarch32-rt-macros", version = "=0.4.0" }
+aarch32-rt-macros = { path = "../aarch32-rt-macros", version = "=0.5.0" }
 
 [features]
 # Enable the FPU on start-up, even on a soft-float EABI target

--- a/aarch32-rt/src/lib.rs
+++ b/aarch32-rt/src/lib.rs
@@ -844,6 +844,10 @@ core::arch::global_asm!(
 );
 
 /// Spins secondary cores.
+///
+/// This function is exported so the linker can use it as a default
+/// implementation of `kmain_secondary`, but it's considered an internal API
+/// that we don't expect you to call.
 #[unsafe(no_mangle)]
 #[cfg(target_arch = "arm")]
 pub extern "C" fn _default_kmain_secondary() {
@@ -859,7 +863,9 @@ pub extern "C" fn _default_kmain_secondary() {
 
 // # _asm_stack_setup_preallocated
 //
-// Configure a stack for every mode. Leaves you in sys mode.
+// Configure a stack for every mode using linker provided constants.
+//
+// Leaves you in SYS mode at the end.
 //
 // Pass the core number in r0
 #[cfg(target_arch = "arm")]

--- a/aarch32-rt/src/lib.rs
+++ b/aarch32-rt/src/lib.rs
@@ -539,7 +539,7 @@
 //!         // Wait until Core 0 does a 'sev'
 //!         wfe
 //!         // Spin until register is non-zero.
-//!         ldr     r1, [r0]  
+//!         ldr     r1, [r0]
 //!         cmp     r1, 0
 //!         beq     1b
 //!         // return to start-up


### PR DESCRIPTION
Prepare an aarch32-rt 0.5 release, with the SMP support.

We should probably have a CHANGELOG checking rule, because filling in the CHANGELOG after the fact is kind of difficult. Hopefully I caught the most important points.
