### PR TITLE
set default=0 for DRACR, DRSR, IRACR, IRSR

### DIFF
--- a/aarch32-cpu/src/register/dracr.rs
+++ b/aarch32-cpu/src/register/dracr.rs
@@ -5,7 +5,7 @@ use arbitrary_int::u3;
 use crate::register::{SysReg, SysRegRead, SysRegWrite};
 
 /// DRACR (*Data Region Access Control Register*)
-#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
+#[bitbybit::bitfield(u32, default = 0, debug, defmt_bitfields(feature = "defmt"))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Dracr {
     /// Execute Never

--- a/aarch32-cpu/src/register/drsr.rs
+++ b/aarch32-cpu/src/register/drsr.rs
@@ -94,7 +94,7 @@ impl RegionSize {
 }
 
 /// DRSR (*Data Region Size and Enable Register*)
-#[bitbybit::bitfield(u32, debug, defmt_fields(feature = "defmt"))]
+#[bitbybit::bitfield(u32, default = 0, debug, defmt_fields(feature = "defmt"))]
 pub struct Drsr {
     /// Sub-region bitmask
     ///

--- a/aarch32-cpu/src/register/iracr.rs
+++ b/aarch32-cpu/src/register/iracr.rs
@@ -5,7 +5,7 @@ use arbitrary_int::u3;
 use crate::register::{SysReg, SysRegRead, SysRegWrite};
 
 /// IRACR (*Instruction Region Access Control Register*)
-#[bitbybit::bitfield(u32, debug, defmt_bitfields(feature = "defmt"))]
+#[bitbybit::bitfield(u32, default = 0, debug, defmt_bitfields(feature = "defmt"))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Iracr {
     /// Execute Never

--- a/aarch32-cpu/src/register/irsr.rs
+++ b/aarch32-cpu/src/register/irsr.rs
@@ -5,7 +5,7 @@ use crate::register::{SysReg, SysRegRead, SysRegWrite};
 pub use super::drsr::RegionSize;
 
 /// IRSR (*Instruction Region Size and Enable Register*)
-#[bitbybit::bitfield(u32, debug, defmt_fields(feature = "defmt"))]
+#[bitbybit::bitfield(u32, default = 0, debug, defmt_fields(feature = "defmt"))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Irsr {
     /// Sub-region bitmask


### PR DESCRIPTION
Add default value for [`Dracr`](https://docs.rs/aarch32-cpu/0.4.0/aarch32_cpu/register/dracr/struct.Dracr.html), [`Drsr`](https://docs.rs/aarch32-cpu/0.4.0/aarch32_cpu/register/drsr/struct.Drsr.html), [`Iracr`](https://docs.rs/aarch32-cpu/0.4.0/aarch32_cpu/register/iracr/struct.Iracr.html) and [`Irsr`](https://docs.rs/aarch32-cpu/0.4.0/aarch32_cpu/register/irsr/struct.Irsr.html) to enable usage of builder pattern, as mentioned in https://github.com/rust-embedded/aarch32/issues/189#issuecomment-4726993322.

The bits not specified in the `bitbybit::bitfield`, are specified as `UNK/SBZP` by the [reference manual](https://support.arm.com/documentation/ddi0406/cb/System-Level-Architecture/System-Control-Registers-in-a-PMSA-implementation/PMSA-System-control-registers-descriptions--in-register-order/DRACR--Data-Region-Access-Control-Register--PMSA?lang=en), so writing zero from software should be correct.