### PR TITLE
avoid explicit .filler section

### DIFF
--- a/aarch32-rt/CHANGELOG.md
+++ b/aarch32-rt/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced .filler padding section with fixed offset for stack placement in link.x
+
 ## [aarch32-rt v0.4.0]
 
 ### Added

--- a/aarch32-rt/link.x
+++ b/aarch32-rt/link.x
@@ -156,24 +156,18 @@ SECTIONS {
 
     /* # Stack Padding
      *
-     * A padding region to push the stacks to the top of the STACKS region.
-     * If `_pack_stacks == 0`, this is forced to be zero size, putting the
-     * stacks at the bottom of the STACK region.
+     * Compute where `.stacks` should start: at the top of the STACKS region,
+     * unless `_pack_stacks == 1`, in which case right where we already are.
      */
-    .filler (NOLOAD) : {
-        /* Move the .stacks section to the end of the STACKS memory region */
-        _next_region = ORIGIN(STACKS) + LENGTH(STACKS);
-        _start_moved_stacks = _next_region - SIZEOF(.stacks);
-        _start_stacks = _pack_stacks ? . : _start_moved_stacks;
-        FILL(0x00)
-        . = _start_stacks;
-    } > STACKS
+    _next_region = ORIGIN(STACKS) + LENGTH(STACKS);
+    _start_moved_stacks = _next_region - SIZEOF(.stacks);
+    _start_stacks = _pack_stacks ? . : _start_moved_stacks;
 
     /* # Stacks
      *
      * Space for all seven stacks.
      */
-    .stacks (NOLOAD) : ALIGN(_stack_alignment)
+    .stacks _start_stacks (NOLOAD) : ALIGN(_stack_alignment)
     {
         . = ALIGN(_stack_alignment);
 


### PR DESCRIPTION
When placing the filler into the STACK region, it counts towards .bss when displaying it with tools like llvm-size. no idea why. when we calculate the start of stacks without a dedicated filler segment, i don't have that issue. however, i still want to do some tests because maybe there was a reason this was done with an explicit section?