### PR TITLE
Force 4 byte alignment for all Arm functions

### DIFF
--- a/aarch32-rt/src/arch_v4/abort.rs
+++ b/aarch32-rt/src/arch_v4/abort.rs
@@ -16,6 +16,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_data_abort_handler
     .type _asm_default_data_abort_handler, %function
+    .p2align 2
     _asm_default_data_abort_handler:
         sub     lr, lr, #8                // Make sure we jump back to the right place
         push    {{ r12 }}                 // Push preserved register R12 (1)
@@ -60,6 +61,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_prefetch_abort_handler
     .type _asm_default_prefetch_abort_handler, %function
+    .p2align 2
     _asm_default_prefetch_abort_handler:
         sub     lr, lr, #4                // Make sure we jump back to the right place
         push    {{ r12 }}                 // Push preserved register R12 (1)

--- a/aarch32-rt/src/arch_v4/boot.rs
+++ b/aarch32-rt/src/arch_v4/boot.rs
@@ -16,6 +16,7 @@ core::arch::global_asm!(
     .arm
     .global _default_start
     .type _default_start, %function
+    .p2align 2
     _default_start:
         // Init .data and .bss on primary core
         bl      _asm_init_segments

--- a/aarch32-rt/src/arch_v4/hvc.rs
+++ b/aarch32-rt/src/arch_v4/hvc.rs
@@ -12,6 +12,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_hvc_handler
     .type _asm_default_hvc_handler, %function
+    .p2align 2
     _asm_default_hvc_handler:
         b       .
     .size _asm_default_hvc_handler, . - _asm_default_hvc_handler

--- a/aarch32-rt/src/arch_v4/interrupt.rs
+++ b/aarch32-rt/src/arch_v4/interrupt.rs
@@ -33,6 +33,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_irq_handler
     .type _asm_default_irq_handler, %function
+    .p2align 2
     _asm_default_irq_handler:
         sub     lr, lr, 4                 // Make sure we jump back to the right place
         stmfd   sp!, {{ lr }}             // Save adjusted LR to IRQ stack (1)

--- a/aarch32-rt/src/arch_v4/svc.rs
+++ b/aarch32-rt/src/arch_v4/svc.rs
@@ -17,6 +17,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_svc_handler
     .type _asm_default_svc_handler, %function
+    .p2align 2
     _asm_default_svc_handler:
         stmfd   sp!, {{ r12, lr }}        // Save LR and R12 (1)
         mrs     r12, spsr                 // Grab SPSR (2)

--- a/aarch32-rt/src/arch_v4/undefined.rs
+++ b/aarch32-rt/src/arch_v4/undefined.rs
@@ -19,6 +19,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_undefined_handler
     .type _asm_default_undefined_handler, %function
+    .p2align 2
     _asm_default_undefined_handler:
         push    {{ r12 }}                 // Push preserved register R12 (1)
         mrs     r12, spsr                 // Grab SPSR (2)

--- a/aarch32-rt/src/arch_v7/abort.rs
+++ b/aarch32-rt/src/arch_v7/abort.rs
@@ -16,6 +16,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_data_abort_handler
     .type _asm_default_data_abort_handler, %function
+    .p2align 2
     _asm_default_data_abort_handler:
         sub     lr, lr, #8                // Make sure we jump back to the right place
         srsfd   sp!, #{abt_mode}          // Store return state to ABT stack (1)
@@ -59,6 +60,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_prefetch_abort_handler
     .type _asm_default_prefetch_abort_handler, %function
+    .p2align 2
     _asm_default_prefetch_abort_handler:
         sub     lr, lr, #4                // Make sure we jump back to the right place
         srsfd   sp!, #{abt_mode}          // Store return state to ABT stack (1)

--- a/aarch32-rt/src/arch_v7/boot_from_el1.rs
+++ b/aarch32-rt/src/arch_v7/boot_from_el1.rs
@@ -15,6 +15,7 @@ core::arch::global_asm!(
     .arm
     .global _default_start
     .type _default_start, %function
+    .p2align 2
     _default_start:
         // Read MPIDR into R0
         mrc     p15, 0, r0, c0, c0, 5

--- a/aarch32-rt/src/arch_v7/boot_from_el2.rs
+++ b/aarch32-rt/src/arch_v7/boot_from_el2.rs
@@ -29,6 +29,7 @@ core::arch::global_asm!(
     .arm
     .global _default_start
     .type _default_start, %function
+    .p2align 2
     _default_start:
         // Read MPIDR into R0
         mrc     p15, 0, r0, c0, c0, 5

--- a/aarch32-rt/src/arch_v7/hvc.rs
+++ b/aarch32-rt/src/arch_v7/hvc.rs
@@ -15,6 +15,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_hvc_handler
     .type _asm_default_hvc_handler, %function
+    .p2align 2
     _asm_default_hvc_handler:
         push    {{ r12, lr }}             // Push preserved registers R12 and LR (1)
         push    {{ r0-r5 }}               // Push HVC frame to stack (2)
@@ -51,6 +52,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_hvc_handler
     .type _asm_default_hvc_handler, %function
+    .p2align 2
     _asm_default_hvc_handler:
         b       .
     .size _asm_default_hvc_handler, . - _asm_default_hvc_handler

--- a/aarch32-rt/src/arch_v7/interrupt.rs
+++ b/aarch32-rt/src/arch_v7/interrupt.rs
@@ -35,6 +35,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_irq_handler
     .type _asm_default_irq_handler, %function
+    .p2align 2
     _asm_default_irq_handler:
         sub     lr, lr, 4                 // Make sure we jump back to the right place
         srsfd   sp!, #{handler_mode}      // Store return state to the handler stack (1)

--- a/aarch32-rt/src/arch_v7/svc.rs
+++ b/aarch32-rt/src/arch_v7/svc.rs
@@ -18,6 +18,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_svc_handler
     .type _asm_default_svc_handler, %function
+    .p2align 2
     _asm_default_svc_handler:
         srsfd   sp!, #{svc_mode}          // Store return state to the SVC stack (1)
         push    {{ r12, lr }}             // Push preserved registers R12 and LR (2)

--- a/aarch32-rt/src/arch_v7/undefined.rs
+++ b/aarch32-rt/src/arch_v7/undefined.rs
@@ -20,6 +20,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_undefined_handler
     .type _asm_default_undefined_handler, %function
+    .p2align 2
     _asm_default_undefined_handler:
         srsfd   sp!, #{und_mode}          // Store return state to the UND stack (1)
         push    {{ r12 }}                 // Push preserved register R12 (2)

--- a/aarch32-rt/src/arch_v8_hyp/abort.rs
+++ b/aarch32-rt/src/arch_v8_hyp/abort.rs
@@ -16,6 +16,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_data_abort_handler
     .type _asm_default_data_abort_handler, %function
+    .p2align 2
     _asm_default_data_abort_handler:
         push    {{ r0-r3, r12, lr }}      // Push preserved registers (1)
         mrs     r0, spsr_hyp              // Grab SPSR (2)
@@ -57,6 +58,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_prefetch_abort_handler
     .type _asm_default_prefetch_abort_handler, %function
+    .p2align 2
     _asm_default_prefetch_abort_handler:
         push    {{ r0-r3, r12, lr }}      // Push preserved registers (1)
         mrs     r0, spsr_hyp              // Grab SPSR (2)

--- a/aarch32-rt/src/arch_v8_hyp/boot.rs
+++ b/aarch32-rt/src/arch_v8_hyp/boot.rs
@@ -15,6 +15,7 @@ core::arch::global_asm!(
     .arm
     .global _default_start
     .type _default_start, %function
+    .p2align 2
     _default_start:
         // Read MPIDR into R0
         mrc     p15, 0, r0, c0, c0, 5

--- a/aarch32-rt/src/arch_v8_hyp/hvc.rs
+++ b/aarch32-rt/src/arch_v8_hyp/hvc.rs
@@ -15,6 +15,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_hvc_handler
     .type _asm_default_hvc_handler, %function
+    .p2align 2
     _asm_default_hvc_handler:
         push    {{ r12, lr }}             // Push preserved registers R12 and LR (1)
         mrs     lr, elr_hyp               // Grab ELR (2)

--- a/aarch32-rt/src/arch_v8_hyp/interrupt.rs
+++ b/aarch32-rt/src/arch_v8_hyp/interrupt.rs
@@ -17,6 +17,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_irq_handler
     .type _asm_default_irq_handler, %function
+    .p2align 2
     _asm_default_irq_handler:
         push    {{ r0-r3, r12, lr }}      // Push preserved registers (1)
         mrs     r0, elr_hyp               // Grab ELR (2)

--- a/aarch32-rt/src/arch_v8_hyp/svc.rs
+++ b/aarch32-rt/src/arch_v8_hyp/svc.rs
@@ -24,6 +24,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_svc_handler
     .type _asm_default_svc_handler, %function
+    .p2align 2
     _asm_default_svc_handler:
         push    {{ r12, lr }}             // Push R12 and LR (1)
         mrs     lr, elr_hyp               // Grab ELR (2)

--- a/aarch32-rt/src/arch_v8_hyp/undefined.rs
+++ b/aarch32-rt/src/arch_v8_hyp/undefined.rs
@@ -19,6 +19,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_undefined_handler
     .type _asm_default_undefined_handler, %function
+    .p2align 2
     _asm_default_undefined_handler:
         push    {{ r0-r3, r12, lr }}      // Push preserved registers (1)
         mrs     r0, spsr_hyp              // Grab SPSR (2)

--- a/aarch32-rt/src/lib.rs
+++ b/aarch32-rt/src/lib.rs
@@ -761,6 +761,7 @@ core::arch::global_asm!(
     .arm
     .global _vector_table
     .type _vector_table, %function
+    .p2align 2
     .align 5
     _vector_table:
         ldr     pc, =_start
@@ -786,8 +787,10 @@ core::arch::global_asm!(
     // Work around https://github.com/rust-lang/rust/issues/127269
     .fpu vfp2
     .pushsection .text._asm_core_start
+    .arm
     .global _asm_core_start
     .type _asm_core_start, %function
+    .p2align 2
     _asm_core_start:
         // Keep our core number for later
         mov     r12, r0
@@ -866,8 +869,10 @@ pub extern "C" fn _default_kmain_secondary() {
 core::arch::global_asm!(
     r#"
     .pushsection .text._asm_stack_setup_preallocated
+    .arm
     .global _asm_stack_setup_preallocated
     .type _asm_stack_setup_preallocated, %function
+    .p2align 2
     _asm_stack_setup_preallocated:
         // Save LR from whatever mode we're currently in
         mov     r3, lr
@@ -967,8 +972,10 @@ core::arch::global_asm!(
     .fpu vfp2
 
     .pushsection .text._asm_init_segments
+    .arm
     .global _asm_init_segments
     .type _asm_init_segments, %function
+    .p2align 2
     _asm_init_segments:
         // Zero .bss
         ldr     r0, =__sbss
@@ -1026,6 +1033,7 @@ core::arch::global_asm!(
     .arm
     .global _asm_default_fiq_handler
     .type _asm_default_fiq_handler, %function
+    .p2align 2
     _asm_default_fiq_handler:
         b       _asm_default_fiq_handler
     .size    _asm_default_fiq_handler, . - _asm_default_fiq_handler


### PR DESCRIPTION
I was seeing an Arm function with 2 byte alignment, which caused a prefetch abort. Now they are all forced to 4 byte alignment.

Also I observed that Rust was assembling all global_asm functions as A32 even on a "thumb*" target. So I've expressly marked them all as ".arm" to avoid surprise.

Fixes #214 