### PR TITLE
Rework exception macro expansion for faults

### DIFF
--- a/aarch32-rt-macros/src/lib.rs
+++ b/aarch32-rt-macros/src/lib.rs
@@ -60,6 +60,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
         && f.sig.generics.params.is_empty()
         && f.sig.generics.where_clause.is_none()
         && f.sig.variadic.is_none()
+        && f.sig.asyncness.is_none()
         && match f.sig.output {
             ReturnType::Default => false,
             ReturnType::Type(_, ref ty) => matches!(**ty, Type::Never(_)),

--- a/aarch32-rt-macros/src/lib.rs
+++ b/aarch32-rt-macros/src/lib.rs
@@ -306,91 +306,52 @@ fn handle_vector(args: TokenStream, input: TokenStream, kind: VectorKind) -> Tok
     };
 
     let func_name = f.sig.ident.clone();
-    let block = f.block.clone();
     let (ref cfgs, ref attrs) = extract_cfgs(f.attrs.clone());
 
     let handler = match exception {
+        // Faulting exceptions that optionally take an address argument
+        //
+        // e.g.
         // extern "C" fn _undefined_handler(addr: usize) -> !;
         // unsafe extern "C" fn _undefined_handler(addr: usize) -> usize;
-        Exception::Undefined => {
-            let tramp_ident = Ident::new("__aarch32_rt_undefined_handler", Span::call_site());
-            if returns_never {
-                quote!(
-                    #(#cfgs)*
-                    #(#attrs)*
-                    #[doc(hidden)]
-                    #[export_name = "_undefined_handler"]
-                    pub unsafe extern "C" fn #tramp_ident(addr: usize) -> ! {
-                        #block
-                    }
+        Exception::Undefined | Exception::DataAbort | Exception::PrefetchAbort => {
+            let fn_output = f.sig.output.clone();
+            let (tramp_ident, export_name) = match exception {
+                Exception::Undefined => (
+                    Ident::new("__aarch32_rt_undefined_handler", Span::call_site()),
+                    "_undefined_handler",
+                ),
+                Exception::DataAbort => (
+                    Ident::new("__aarch32_rt_data_abort_handler", Span::call_site()),
+                    "_data_abort_handler",
+                ),
+                Exception::PrefetchAbort => (
+                    Ident::new("__aarch32_rt_prefetch_abort_handler", Span::call_site()),
+                    "_prefetch_abort_handler",
+                ),
+                _ => unreachable!(),
+            };
 
+            let call_site = if f.sig.inputs.is_empty() {
+                quote!(
+                    #func_name()
                 )
             } else {
                 quote!(
-                    #(#cfgs)*
-                    #(#attrs)*
-                    #[doc(hidden)]
-                    #[export_name = "_undefined_handler"]
-                    pub unsafe extern "C" fn #tramp_ident(addr: usize) -> usize {
-                        #block
-                    }
+                    #func_name(_addr)
+                )
+            };
 
-                )
-            }
-        }
-        // extern "C" fn _prefetch_abort_handler(addr: usize) -> !;
-        // unsafe extern "C" fn _prefetch_abort_handler(addr: usize) -> usize;
-        Exception::PrefetchAbort => {
-            let tramp_ident = Ident::new("__aarch32_rt_prefetch_abort_handler", Span::call_site());
-            if returns_never {
-                quote!(
-                    #(#cfgs)*
-                    #(#attrs)*
-                    #[doc(hidden)]
-                    #[export_name = "_prefetch_abort_handler"]
-                    pub unsafe extern "C" fn #tramp_ident(addr: usize) -> ! {
-                        #block
-                    }
-                )
-            } else {
-                quote!(
-                    #(#cfgs)*
-                    #(#attrs)*
-                    #[doc(hidden)]
-                    #[export_name = "_prefetch_abort_handler"]
-                    pub unsafe extern "C" fn #tramp_ident(addr: usize) -> usize {
-                        #block
-                    }
-
-                )
-            }
-        }
-        // extern "C" fn _data_abort_handler(addr: usize) -> !;
-        // unsafe extern "C" fn _data_abort_handler(addr: usize) -> usize;
-        Exception::DataAbort => {
-            let tramp_ident = Ident::new("__aarch32_rt_data_abort_handler", Span::call_site());
-            if returns_never {
-                quote!(
-                    #(#cfgs)*
-                    #(#attrs)*
-                    #[doc(hidden)]
-                    #[export_name = "_data_abort_handler"]
-                    pub unsafe extern "C" fn #tramp_ident(addr: usize) -> ! {
-                        #block
-                    }
-
-                )
-            } else {
-                quote!(
-                    #(#cfgs)*
-                    #(#attrs)*
-                    #[doc(hidden)]
-                    #[export_name = "_data_abort_handler"]
-                    pub unsafe extern "C" fn #tramp_ident(addr: usize) -> usize {
-                        #block
-                    }
-                )
-            }
+            quote!(
+                #(#cfgs)*
+                #(#attrs)*
+                #[doc(hidden)]
+                #[export_name = #export_name]
+                pub unsafe extern "C" fn #tramp_ident(_addr: usize) #fn_output {
+                    #f
+                    #call_site
+                }
+            )
         }
         // extern "C" fn _svc_handler(arg: u32, args: &Frame) -> u32
         Exception::SupervisorCall => {
@@ -425,13 +386,24 @@ fn handle_vector(args: TokenStream, input: TokenStream, kind: VectorKind) -> Tok
         // extern "C" fn _irq_handler(addr: usize);
         Exception::Irq => {
             let tramp_ident = Ident::new("__aarch32_rt_irq_handler", Span::call_site());
+            let call_site = if f.sig.inputs.is_empty() {
+                quote!(
+                    #func_name()
+                )
+            } else {
+                quote!(
+                    #func_name(_addr)
+                )
+            };
+
             quote!(
                 #(#cfgs)*
                 #(#attrs)*
                 #[doc(hidden)]
                 #[export_name = "_irq_handler"]
                 pub unsafe extern "C" fn #tramp_ident() {
-                    #block
+                    #f
+                    #call_site
                 }
             )
         }


### PR DESCRIPTION
Closes #221. This also prevents marking `#[entry]`s as `async`, since that's a no-op (I guess that's technically a breaking change, so I can revert that if needed).

example:

```rs
#[exception(DataAbort)]
fn data_abort_handler() -> ! {
    loop {}
}

// now roughly expands to...

#[doc(hidden)]
#[export_name = "_data_abort_handler"]
pub unsafe extern "C" fn __aarch32_rt_data_abort_handler (_addr : usize) -> ! {
    fn data_abort_handler () -> ! { loop { } }

    // If `data_abort_handler` had one or more params, the macro would try to pass it `_addr`.
    data_abort_handler()
}
```

This is a draft because there are still some other potential edge cases and things i'm not sure of, notably:
- Is the intention of attributes on exceptions for them to go on the outer function or the inner function? (right now it does both, which is probably (?) bad, but changing that behavior would also be *maybe* breaking since `Exception::SupervisorCall` has always done that). If it's the latter only, is `check_attr_whitelist` still necessary?
- Should we do additional validation on the inner function's signature like `#[entry]` does for clearer user errors, e.g. if the user tried to mark their IRQ handler as `async` or something?
- Should we validate the argument type validation for `addr` in the macro? This should now fail after expansion because the macro will attempt to pass the inner function a `usize`, but we could catch it earlier if we wanted.
- unit tests maybe?